### PR TITLE
Add a shared actor interface definition

### DIFF
--- a/rt/actor.go
+++ b/rt/actor.go
@@ -1,0 +1,33 @@
+package rt
+
+import (
+	"github.com/filecoin-project/go-state-types/cbor"
+	"github.com/ipfs/go-cid"
+)
+
+// VMActor is a concrete implementation of an actor, to be used by a Filecoin
+// VM.
+type VMActor interface {
+	// Exports returns a slice of methods exported by this actor, indexed by
+	// method number. Skipped/deprecated method numbers will be nil.
+	Exports() []interface{}
+
+	// Code returns the code ID for this actor.
+	Code() cid.Cid
+
+	// State returns a new State object for this actor. This can be used to
+	// decode the actor's state.
+	State() cbor.Er
+
+	// NOTE: methods like "IsSingleton" are intentionally excluded from this
+	// interface. That way, we can add additional attributes actors in newer
+	// specs-actors versions, without having to update previous specs-actors
+	// versions.
+}
+
+// IsSingletonActor returns true if the actor is a singleton actor (i.e., cannot
+// be constructed).
+func IsSingletonActor(a VMActor) bool {
+	s, ok := a.(interface{ IsSingleton() bool })
+	return ok && s.IsSingleton()
+}


### PR DESCRIPTION
Ideally, this would just be defined in lotus (where the type is used).

However, I'd like to change the `BuiltinActors()` method in specs-actors to return `[]Actor`. This way, all actors for a specific specs-actors version can be registered with the lotus vm with a single `vm.Register(..., BuiltinActors()...)` call.

Unfortunately, the type `[]actors0.Actor` is not the same as `[]actors1.Actor`, even if `actors0.Actor` and `actors1.Actor` are identical interfaces. Hence the definition in this package.