### PR TITLE
fill in new network versions

### DIFF
--- a/network/version.go
+++ b/network/version.go
@@ -7,11 +7,13 @@ import "math"
 type Version uint
 
 const (
-	Version0 = Version(iota) // specs-actors v0.9.3
-	Version1                 // specs-actors v0.9.7
-	Version2                 // specs-actors v0.9.?
-	Version3                 // Coming soon
-	Version4                 // Who knows?
+	Version0 = Version(iota) // genesis   (specs-actors v0.9.3)
+	Version1                 // breeze    (specs-actors v0.9.7)
+	Version2                 // smoke     (specs-actors v0.9.8)
+	Version3                 // ignition  (specs-actors v0.9.11)
+	Version4                 // actors v2 (specs-actors v2.0.x (future))
+	Version5                 // sometime?
 
+	// VersionMax is the maximum version number
 	VersionMax = Version(math.MaxUint32)
 )


### PR DESCRIPTION
This patch adds a version 5 (pending, may change), and provides a "version count" for convenience.