### PR TITLE
Prep for upcoming upgrades

### DIFF
--- a/network/version.go
+++ b/network/version.go
@@ -11,8 +11,9 @@ const (
 	Version1                 // breeze    (specs-actors v0.9.7)
 	Version2                 // smoke     (specs-actors v0.9.8)
 	Version3                 // ignition  (specs-actors v0.9.11)
-	Version4                 // actors v2 (specs-actors v2.0.x (future))
-	Version5                 // sometime?
+	Version4                 // actors v2 (specs-actors v2.0.3)
+	Version5                 // tape      (specs-actors v2.1.0)
+	Version6                 // upcoming
 
 	// VersionMax is the maximum version number
 	VersionMax = Version(math.MaxUint32)


### PR DESCRIPTION
Should we speculatively add 7,8,9,10 so we can save a few minutes when developing upgrades under pressure in the next few weeks?