### PR TITLE
add network versions

### DIFF
--- a/network/version.go
+++ b/network/version.go
@@ -13,11 +13,10 @@ const (
 	Version3                 // ignition  (specs-actors v0.9.11)
 	Version4                 // actors v2 (specs-actors v2.0.3)
 	Version5                 // tape      (specs-actors v2.1.0)
-	Version6                 // pledge changes (specs-actors v2.2.0)
+	Version6                 // pending   (specs-actors v2.2.0)
         Version7                 // upcoming
         Version8                 // reserved
         Version9                 // reserved
-        Version10                // reserved
 
 	// VersionMax is the maximum version number
 	VersionMax = Version(math.MaxUint32)

--- a/network/version.go
+++ b/network/version.go
@@ -14,9 +14,9 @@ const (
 	Version4                 // actors v2 (specs-actors v2.0.3)
 	Version5                 // tape      (specs-actors v2.1.0)
 	Version6                 // pending   (specs-actors v2.2.0)
-        Version7                 // upcoming
-        Version8                 // reserved
-        Version9                 // reserved
+	Version7                 // upcoming
+	Version8                 // reserved
+	Version9                 // reserved
 
 	// VersionMax is the maximum version number
 	VersionMax = Version(math.MaxUint32)

--- a/network/version.go
+++ b/network/version.go
@@ -13,7 +13,11 @@ const (
 	Version3                 // ignition  (specs-actors v0.9.11)
 	Version4                 // actors v2 (specs-actors v2.0.3)
 	Version5                 // tape      (specs-actors v2.1.0)
-	Version6                 // upcoming
+	Version6                 // pledge changes (specs-actors v2.2.0)
+        Version7                 // upcoming
+        Version8                 // reserved
+        Version9                 // reserved
+        Version10                // reserved
 
 	// VersionMax is the maximum version number
 	VersionMax = Version(math.MaxUint32)

--- a/network/version.go
+++ b/network/version.go
@@ -13,7 +13,7 @@ const (
 	Version3                 // ignition  (specs-actors v0.9.11)
 	Version4                 // actors v2 (specs-actors v2.0.3)
 	Version5                 // tape      (specs-actors v2.1.0)
-	Version6                 // pending   (specs-actors v2.2.0)
+	Version6                 // kumquat   (specs-actors v2.2.0)
 	Version7                 // upcoming
 	Version8                 // reserved
 	Version9                 // reserved


### PR DESCRIPTION
### Motivation

Network version 6 is ready to be shipped. We need new version numbers to flag specs actor changes.