### PR TITLE
Properly guard against 'hollow' objects

### DIFF
--- a/big/int.go
+++ b/big/int.go
@@ -32,6 +32,8 @@ func Zero() Int {
 	return NewInt(0)
 }
 
+var reusableZero = Zero()
+
 // PositiveFromUnsignedBytes interprets b as the bytes of a big-endian unsigned
 // integer and returns a positive Int with this absolute value.
 func PositiveFromUnsignedBytes(b []byte) Int {
@@ -59,6 +61,9 @@ func FromString(s string) (Int, error) {
 }
 
 func (bi Int) Copy() Int {
+	if bi.Int == nil {
+		return NewInt(0)
+	}
 	return Int{Int: new(big.Int).Set(bi.Int)}
 }
 
@@ -71,18 +76,42 @@ func Product(ints ...Int) Int {
 }
 
 func Mul(a, b Int) Int {
+	if a.Int == nil {
+		a = reusableZero
+	}
+	if b.Int == nil {
+		b = reusableZero
+	}
 	return Int{big.NewInt(0).Mul(a.Int, b.Int)}
 }
 
 func Div(a, b Int) Int {
+	if a.Int == nil {
+		a = reusableZero
+	}
+	if b.Int == nil {
+		b = reusableZero
+	}
 	return Int{big.NewInt(0).Div(a.Int, b.Int)}
 }
 
 func Mod(a, b Int) Int {
+	if a.Int == nil {
+		a = reusableZero
+	}
+	if b.Int == nil {
+		b = reusableZero
+	}
 	return Int{big.NewInt(0).Mod(a.Int, b.Int)}
 }
 
 func Add(a, b Int) Int {
+	if a.Int == nil {
+		a = reusableZero
+	}
+	if b.Int == nil {
+		b = reusableZero
+	}
 	return Int{big.NewInt(0).Add(a.Int, b.Int)}
 }
 
@@ -103,25 +132,46 @@ func Subtract(num1 Int, ints ...Int) Int {
 }
 
 func Sub(a, b Int) Int {
+	if a.Int == nil {
+		a = reusableZero
+	}
+	if b.Int == nil {
+		b = reusableZero
+	}
 	return Int{big.NewInt(0).Sub(a.Int, b.Int)}
 }
 
 //  Returns a**e unless e <= 0 (in which case returns 1).
 func Exp(a Int, e Int) Int {
+	if a.Int == nil {
+		a = reusableZero
+	}
+	if e.Int == nil {
+		e = reusableZero
+	}
 	return Int{big.NewInt(0).Exp(a.Int, e.Int, nil)}
 }
 
 // Returns x << n
 func Lsh(a Int, n uint) Int {
+	if a.Int == nil {
+		return NewInt(0)
+	}
 	return Int{big.NewInt(0).Lsh(a.Int, n)}
 }
 
 // Returns x >> n
 func Rsh(a Int, n uint) Int {
+	if a.Int == nil {
+		return NewInt(0)
+	}
 	return Int{big.NewInt(0).Rsh(a.Int, n)}
 }
 
 func BitLen(a Int) uint {
+	if a.Int == nil {
+		return 0
+	}
 	return uint(a.Int.BitLen())
 }
 
@@ -154,6 +204,12 @@ func Min(x, y Int) Int {
 }
 
 func Cmp(a, b Int) int {
+	if a.Int == nil {
+		a = reusableZero
+	}
+	if b.Int == nil {
+		b = reusableZero
+	}
 	return a.Int.Cmp(b.Int)
 }
 
@@ -337,8 +393,9 @@ func (bi *Int) UnmarshalCBOR(br io.Reader) error {
 	return nil
 }
 
+// IsZero is identical to NilOrZero
 func (bi *Int) IsZero() bool {
-	return bi.Int.Sign() == 0
+	return bi.Int == nil || bi.Int.Sign() == 0
 }
 
 func (bi *Int) Nil() bool {

--- a/big/int_test.go
+++ b/big/int_test.go
@@ -2,6 +2,7 @@ package big
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"testing"
@@ -114,6 +115,36 @@ func TestOperations(t *testing.T) {
 
 	ta = Int{}
 	assert.True(t, ta.Nil())
+}
+
+func TestInt_NilUnmarshal(t *testing.T) {
+
+	parsedStruct := func() (s struct{ Big Int }) {
+		require.NoError(t, json.Unmarshal([]byte("{}"), &s))
+		return s
+	}
+
+	for _, testCase := range []struct {
+		name     string
+		f        func(Int, Int) Int
+		expected Int
+	}{
+		{name: "Sum", f: Add, expected: NewInt(1000)},
+		{name: "Sub", f: Sub, expected: NewInt(-1000)},
+		{name: "Mul", f: Mul, expected: NewInt(0)},
+		{name: "Div", f: Div, expected: NewInt(0)},
+		{name: "Mod", f: Mod, expected: NewInt(0)},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.expected, testCase.f(parsedStruct().Big, Int{Int: big.NewInt(1000)}))
+		})
+	}
+
+	s := parsedStruct()
+	assert.True(t, s.Big.IsZero())
+
+	s = parsedStruct()
+	assert.True(t, s.Big.Nil())
 }
 
 func TestCopy(t *testing.T) {


### PR DESCRIPTION
These are often instantiated as part of a larger struct unmarshall
A test for this exact scenario is included - refer to it for exact scenario we are guarding against

This is a very fundamental library. **Do not merge without sign-offs from**
- @ZenGround0 
- @anorth 
- @Kubuxu 
- @Stebalien 

( PR from personal account due to lack of perms )