### PR TITLE
Tweak JSON marshaling of labels

### DIFF
--- a/builtin/v8/market/deal.go
+++ b/builtin/v8/market/deal.go
@@ -160,28 +160,27 @@ func (label *DealLabel) UnmarshalCBOR(br io.Reader) error {
 }
 
 func (label DealLabel) MarshalJSON() ([]byte, error) {
-	return json.Marshal(label.bs)
+	if !label.IsString() {
+		return json.Marshal("")
+	}
+
+	str, err := label.ToString()
+	if err != nil {
+		return nil, xerrors.Errorf("failed to convert to string: %w", err)
+	}
+
+	return json.Marshal(str)
 }
 
 func (label *DealLabel) UnmarshalJSON(b []byte) error {
-	var bs []byte
-	if err := json.Unmarshal(b, &bs); err != nil {
-		return xerrors.Errorf("failed to unmarshal bytes: %w", err)
+	var str string
+	if err := json.Unmarshal(b, &str); err != nil {
+		return xerrors.Errorf("failed to unmarshal string: %w", err)
 	}
 
-	if utf8.ValidString(string(bs)) {
-		newLabel, err := NewLabelFromString(string(bs))
-		if err != nil {
-			return xerrors.Errorf("failed to create label from string: %w", err)
-		}
-
-		*label = newLabel
-		return nil
-	}
-
-	newLabel, err := NewLabelFromBytes(bs)
+	newLabel, err := NewLabelFromString(str)
 	if err != nil {
-		return xerrors.Errorf("failed to create label from bytes: %w", err)
+		return xerrors.Errorf("failed to create label from string: %w", err)
 	}
 
 	*label = newLabel

--- a/builtin/v8/market/deal_test.go
+++ b/builtin/v8/market/deal_test.go
@@ -194,11 +194,14 @@ func TestDealLabelJSON(t *testing.T) {
 	require.NoError(t, err, "failed to JSON marshal deal proposal")
 	dp2 = market.DealProposal{}
 	require.NoError(t, json.Unmarshal(dpJSON, &dp2))
-	assert.True(t, dp2.Label.IsBytes())
-	assert.False(t, dp2.Label.IsString())
-	bs, err := dp2.Label.ToBytes()
+	// a JSON-unmarshaled label is always string type
+	assert.False(t, dp2.Label.IsBytes())
+	assert.True(t, dp2.Label.IsString())
+
+	// it can be converted ToString, but it's empty
+	str, err = dp2.Label.ToString()
 	assert.NoError(t, err)
-	assert.Equal(t, bs, []byte{0xde, 0xad, 0xbe, 0xef})
+	assert.Equal(t, str, "")
 }
 
 func TestDealLabelFromCBOR(t *testing.T) {


### PR DESCRIPTION
The new approach is to:

- marshal string-type labels as the string 
- marshal byte-type labels as the empty string
- unmarshal all labels as strings, and set them to string-type labels.

This isn't strictly correct, as a byte-type label will fail the round trip, but that is not a case we are much concerned about supporting yet.