### PR TITLE
fix: verifreg: RmDcProposalID should not be a struct

### DIFF
--- a/builtin/v8/gen/gen.go
+++ b/builtin/v8/gen/gen.go
@@ -191,7 +191,6 @@ func main() {
 		// other types
 		verifreg.RemoveDataCapRequest{},
 		verifreg.RemoveDataCapProposal{},
-		verifreg.RmDcProposalID{},
 	); err != nil {
 		panic(err)
 	}

--- a/builtin/v8/verifreg/cbor_gen.go
+++ b/builtin/v8/verifreg/cbor_gen.go
@@ -590,6 +590,8 @@ func (t *RemoveDataCapProposal) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
+	scratch := make([]byte, 9)
+
 	// t.VerifiedClient (address.Address) (struct)
 	if err := t.VerifiedClient.MarshalCBOR(w); err != nil {
 		return err
@@ -600,10 +602,12 @@ func (t *RemoveDataCapProposal) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.RemovalProposalID (verifreg.RmDcProposalID) (struct)
-	if err := t.RemovalProposalID.MarshalCBOR(w); err != nil {
+	// t.RemovalProposalID (uint64) (uint64)
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.RemovalProposalID)); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -643,59 +647,7 @@ func (t *RemoveDataCapProposal) UnmarshalCBOR(r io.Reader) error {
 		}
 
 	}
-	// t.RemovalProposalID (verifreg.RmDcProposalID) (struct)
-
-	{
-
-		if err := t.RemovalProposalID.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.RemovalProposalID: %w", err)
-		}
-
-	}
-	return nil
-}
-
-var lengthBufRmDcProposalID = []byte{129}
-
-func (t *RmDcProposalID) MarshalCBOR(w io.Writer) error {
-	if t == nil {
-		_, err := w.Write(cbg.CborNull)
-		return err
-	}
-	if _, err := w.Write(lengthBufRmDcProposalID); err != nil {
-		return err
-	}
-
-	scratch := make([]byte, 9)
-
-	// t.ProposalID (uint64) (uint64)
-
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.ProposalID)); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (t *RmDcProposalID) UnmarshalCBOR(r io.Reader) error {
-	*t = RmDcProposalID{}
-
-	br := cbg.GetPeeker(r)
-	scratch := make([]byte, 8)
-
-	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
-	if err != nil {
-		return err
-	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
-	}
-
-	if extra != 1 {
-		return fmt.Errorf("cbor input had wrong number of fields")
-	}
-
-	// t.ProposalID (uint64) (uint64)
+	// t.RemovalProposalID (uint64) (uint64)
 
 	{
 
@@ -706,7 +658,7 @@ func (t *RmDcProposalID) UnmarshalCBOR(r io.Reader) error {
 		if maj != cbg.MajUnsignedInt {
 			return fmt.Errorf("wrong type for uint64 field")
 		}
-		t.ProposalID = uint64(extra)
+		t.RemovalProposalID = uint64(extra)
 
 	}
 	return nil

--- a/builtin/v8/verifreg/verified_registry_state.go
+++ b/builtin/v8/verifreg/verified_registry_state.go
@@ -17,9 +17,7 @@ type DataCap = abi.StoragePower
 
 const SignatureDomainSeparation_RemoveDataCap = "fil_removedatacap:"
 
-type RmDcProposalID struct {
-	ProposalID uint64
-}
+type RmDcProposalID = uint64
 
 type State struct {
 	// Root key holder multisig.


### PR DESCRIPTION
This field isn't serialized as a tuple in v8, but instead as an int. See https://github.com/filecoin-project/builtin-actors/pull/574 for more.