### PR TITLE
Use sync blockstore for parallel migration test

### DIFF
--- a/builtin/v9/migration/test/parallel_migration_test.go
+++ b/builtin/v9/migration/test/parallel_migration_test.go
@@ -18,10 +18,10 @@ func TestParallelMigrationCalls(t *testing.T) {
 	// Construct simple prior state tree over a synchronized store
 	ctx := context.Background()
 	log := migration.TestLogger{TB: t}
-	bs := cbor.NewMemCborStore()
+	bs := NewSyncBlockStoreInMemory()
 
 	// Run migration
-	adtStore := adt.WrapStore(ctx, bs)
+	adtStore := adt.WrapStore(ctx, cbor.NewCborStore(bs))
 	startRoot := makeInputTree(ctx, t, adtStore)
 	newManifestCid, _ := makeTestManifest(t, adtStore, "fil/9/")
 	endRootSerial, err := migration.MigrateStateTree(ctx, adtStore, newManifestCid, startRoot, abi.ChainEpoch(0), migration.Config{MaxWorkers: 1}, log, migration.NewMemMigrationCache())

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/filecoin-project/go-amt-ipld/v4 v4.0.0
 	github.com/filecoin-project/go-bitfield v0.2.4
 	github.com/filecoin-project/go-hamt-ipld/v3 v3.1.0
+	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-ipld-cbor v0.0.6
 	github.com/multiformats/go-multibase v0.0.3


### PR DESCRIPTION
Bug introduced in #46, the parallel test needs a sync blockstore.