### PR TITLE
Lift missed DealUpdatesInterval into state-types

### DIFF
--- a/builtin/v8/market/policy.go
+++ b/builtin/v8/market/policy.go
@@ -6,6 +6,9 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
+// The number of epochs between payment and other state processing for deals.
+const DealUpdatesInterval = builtin.EpochsInDay // PARAM_SPEC
+
 // The percentage of normalized cirulating
 // supply that must be covered by provider collateral in a deal
 var ProviderCollateralSupplyTarget = builtin.BigFrac{


### PR DESCRIPTION
Thank you for pulling the types into their own package, this is excellent work!

I was looking through a codebase, and was able to replace all my uses of `github.com/filecoin-project/specs-actors` with `github.com/filecoin-project/go-state-types` ... except for this one case: https://github.com/filecoin-project/evergreen-dealer/blob/dbbaf53e90960a/cron/trackdeals.go#L219-L221

Proposing to lift `DealUpdatesInterval` into go-state-types just like it is in actors: https://github.com/filecoin-project/specs-actors/blob/v8.0.1/actors/builtin/market/policy.go#L11