### PR TITLE
Several v9 types fixes

### DIFF
--- a/builtin/v8/gen/gen.go
+++ b/builtin/v8/gen/gen.go
@@ -102,6 +102,12 @@ func main() {
 		power.State{},
 		power.Claim{},
 		// method params and returns
+		power.UpdateClaimedPowerParams{},
+		power.MinerConstructorParams{},
+		power.CreateMinerParams{},
+		power.CreateMinerReturn{},
+		power.CurrentTotalPowerReturn{},
+		power.EnrollCronEventParams{},
 	); err != nil {
 		panic(err)
 	}

--- a/builtin/v8/gen/gen.go
+++ b/builtin/v8/gen/gen.go
@@ -56,6 +56,8 @@ func main() {
 		// actor state
 		reward.State{},
 		// method params and returns
+		reward.ThisEpochRewardReturn{},
+		reward.AwardBlockRewardParams{},
 	); err != nil {
 		panic(err)
 	}

--- a/builtin/v8/power/cbor_gen.go
+++ b/builtin/v8/power/cbor_gen.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 
+	address "github.com/filecoin-project/go-address"
 	abi "github.com/filecoin-project/go-state-types/abi"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	xerrors "golang.org/x/xerrors"
@@ -450,6 +451,775 @@ func (t *Claim) UnmarshalCBOR(r io.Reader) error {
 			return xerrors.Errorf("unmarshaling t.QualityAdjPower: %w", err)
 		}
 
+	}
+	return nil
+}
+
+var lengthBufUpdateClaimedPowerParams = []byte{130}
+
+func (t *UpdateClaimedPowerParams) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufUpdateClaimedPowerParams); err != nil {
+		return err
+	}
+
+	// t.RawByteDelta (big.Int) (struct)
+	if err := t.RawByteDelta.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.QualityAdjustedDelta (big.Int) (struct)
+	if err := t.QualityAdjustedDelta.MarshalCBOR(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *UpdateClaimedPowerParams) UnmarshalCBOR(r io.Reader) error {
+	*t = UpdateClaimedPowerParams{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 2 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.RawByteDelta (big.Int) (struct)
+
+	{
+
+		if err := t.RawByteDelta.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.RawByteDelta: %w", err)
+		}
+
+	}
+	// t.QualityAdjustedDelta (big.Int) (struct)
+
+	{
+
+		if err := t.QualityAdjustedDelta.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.QualityAdjustedDelta: %w", err)
+		}
+
+	}
+	return nil
+}
+
+var lengthBufMinerConstructorParams = []byte{134}
+
+func (t *MinerConstructorParams) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufMinerConstructorParams); err != nil {
+		return err
+	}
+
+	scratch := make([]byte, 9)
+
+	// t.OwnerAddr (address.Address) (struct)
+	if err := t.OwnerAddr.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.WorkerAddr (address.Address) (struct)
+	if err := t.WorkerAddr.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.ControlAddrs ([]address.Address) (slice)
+	if len(t.ControlAddrs) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.ControlAddrs was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.ControlAddrs))); err != nil {
+		return err
+	}
+	for _, v := range t.ControlAddrs {
+		if err := v.MarshalCBOR(w); err != nil {
+			return err
+		}
+	}
+
+	// t.WindowPoStProofType (abi.RegisteredPoStProof) (int64)
+	if t.WindowPoStProofType >= 0 {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.WindowPoStProofType)); err != nil {
+			return err
+		}
+	} else {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.WindowPoStProofType-1)); err != nil {
+			return err
+		}
+	}
+
+	// t.PeerId ([]uint8) (slice)
+	if len(t.PeerId) > cbg.ByteArrayMaxLen {
+		return xerrors.Errorf("Byte array in field t.PeerId was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(t.PeerId))); err != nil {
+		return err
+	}
+
+	if _, err := w.Write(t.PeerId[:]); err != nil {
+		return err
+	}
+
+	// t.Multiaddrs ([][]uint8) (slice)
+	if len(t.Multiaddrs) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.Multiaddrs was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Multiaddrs))); err != nil {
+		return err
+	}
+	for _, v := range t.Multiaddrs {
+		if len(v) > cbg.ByteArrayMaxLen {
+			return xerrors.Errorf("Byte array in field v was too long")
+		}
+
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(v))); err != nil {
+			return err
+		}
+
+		if _, err := w.Write(v[:]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *MinerConstructorParams) UnmarshalCBOR(r io.Reader) error {
+	*t = MinerConstructorParams{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 6 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.OwnerAddr (address.Address) (struct)
+
+	{
+
+		if err := t.OwnerAddr.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.OwnerAddr: %w", err)
+		}
+
+	}
+	// t.WorkerAddr (address.Address) (struct)
+
+	{
+
+		if err := t.WorkerAddr.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.WorkerAddr: %w", err)
+		}
+
+	}
+	// t.ControlAddrs ([]address.Address) (slice)
+
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("t.ControlAddrs: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.ControlAddrs = make([]address.Address, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+
+		var v address.Address
+		if err := v.UnmarshalCBOR(br); err != nil {
+			return err
+		}
+
+		t.ControlAddrs[i] = v
+	}
+
+	// t.WindowPoStProofType (abi.RegisteredPoStProof) (int64)
+	{
+		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+		var extraI int64
+		if err != nil {
+			return err
+		}
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative oveflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.WindowPoStProofType = abi.RegisteredPoStProof(extraI)
+	}
+	// t.PeerId ([]uint8) (slice)
+
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.ByteArrayMaxLen {
+		return fmt.Errorf("t.PeerId: byte array too large (%d)", extra)
+	}
+	if maj != cbg.MajByteString {
+		return fmt.Errorf("expected byte array")
+	}
+
+	if extra > 0 {
+		t.PeerId = make([]uint8, extra)
+	}
+
+	if _, err := io.ReadFull(br, t.PeerId[:]); err != nil {
+		return err
+	}
+	// t.Multiaddrs ([][]uint8) (slice)
+
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("t.Multiaddrs: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.Multiaddrs = make([][]uint8, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+
+			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+
+			if extra > cbg.ByteArrayMaxLen {
+				return fmt.Errorf("t.Multiaddrs[i]: byte array too large (%d)", extra)
+			}
+			if maj != cbg.MajByteString {
+				return fmt.Errorf("expected byte array")
+			}
+
+			if extra > 0 {
+				t.Multiaddrs[i] = make([]uint8, extra)
+			}
+
+			if _, err := io.ReadFull(br, t.Multiaddrs[i][:]); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+var lengthBufCreateMinerParams = []byte{133}
+
+func (t *CreateMinerParams) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufCreateMinerParams); err != nil {
+		return err
+	}
+
+	scratch := make([]byte, 9)
+
+	// t.Owner (address.Address) (struct)
+	if err := t.Owner.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.Worker (address.Address) (struct)
+	if err := t.Worker.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.WindowPoStProofType (abi.RegisteredPoStProof) (int64)
+	if t.WindowPoStProofType >= 0 {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.WindowPoStProofType)); err != nil {
+			return err
+		}
+	} else {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.WindowPoStProofType-1)); err != nil {
+			return err
+		}
+	}
+
+	// t.Peer ([]uint8) (slice)
+	if len(t.Peer) > cbg.ByteArrayMaxLen {
+		return xerrors.Errorf("Byte array in field t.Peer was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(t.Peer))); err != nil {
+		return err
+	}
+
+	if _, err := w.Write(t.Peer[:]); err != nil {
+		return err
+	}
+
+	// t.Multiaddrs ([][]uint8) (slice)
+	if len(t.Multiaddrs) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.Multiaddrs was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Multiaddrs))); err != nil {
+		return err
+	}
+	for _, v := range t.Multiaddrs {
+		if len(v) > cbg.ByteArrayMaxLen {
+			return xerrors.Errorf("Byte array in field v was too long")
+		}
+
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(v))); err != nil {
+			return err
+		}
+
+		if _, err := w.Write(v[:]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *CreateMinerParams) UnmarshalCBOR(r io.Reader) error {
+	*t = CreateMinerParams{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 5 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.Owner (address.Address) (struct)
+
+	{
+
+		if err := t.Owner.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.Owner: %w", err)
+		}
+
+	}
+	// t.Worker (address.Address) (struct)
+
+	{
+
+		if err := t.Worker.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.Worker: %w", err)
+		}
+
+	}
+	// t.WindowPoStProofType (abi.RegisteredPoStProof) (int64)
+	{
+		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+		var extraI int64
+		if err != nil {
+			return err
+		}
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative oveflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.WindowPoStProofType = abi.RegisteredPoStProof(extraI)
+	}
+	// t.Peer ([]uint8) (slice)
+
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.ByteArrayMaxLen {
+		return fmt.Errorf("t.Peer: byte array too large (%d)", extra)
+	}
+	if maj != cbg.MajByteString {
+		return fmt.Errorf("expected byte array")
+	}
+
+	if extra > 0 {
+		t.Peer = make([]uint8, extra)
+	}
+
+	if _, err := io.ReadFull(br, t.Peer[:]); err != nil {
+		return err
+	}
+	// t.Multiaddrs ([][]uint8) (slice)
+
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("t.Multiaddrs: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.Multiaddrs = make([][]uint8, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+
+			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+
+			if extra > cbg.ByteArrayMaxLen {
+				return fmt.Errorf("t.Multiaddrs[i]: byte array too large (%d)", extra)
+			}
+			if maj != cbg.MajByteString {
+				return fmt.Errorf("expected byte array")
+			}
+
+			if extra > 0 {
+				t.Multiaddrs[i] = make([]uint8, extra)
+			}
+
+			if _, err := io.ReadFull(br, t.Multiaddrs[i][:]); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+var lengthBufCreateMinerReturn = []byte{130}
+
+func (t *CreateMinerReturn) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufCreateMinerReturn); err != nil {
+		return err
+	}
+
+	// t.IDAddress (address.Address) (struct)
+	if err := t.IDAddress.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.RobustAddress (address.Address) (struct)
+	if err := t.RobustAddress.MarshalCBOR(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *CreateMinerReturn) UnmarshalCBOR(r io.Reader) error {
+	*t = CreateMinerReturn{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 2 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.IDAddress (address.Address) (struct)
+
+	{
+
+		if err := t.IDAddress.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.IDAddress: %w", err)
+		}
+
+	}
+	// t.RobustAddress (address.Address) (struct)
+
+	{
+
+		if err := t.RobustAddress.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.RobustAddress: %w", err)
+		}
+
+	}
+	return nil
+}
+
+var lengthBufCurrentTotalPowerReturn = []byte{132}
+
+func (t *CurrentTotalPowerReturn) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufCurrentTotalPowerReturn); err != nil {
+		return err
+	}
+
+	// t.RawBytePower (big.Int) (struct)
+	if err := t.RawBytePower.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.QualityAdjPower (big.Int) (struct)
+	if err := t.QualityAdjPower.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.PledgeCollateral (big.Int) (struct)
+	if err := t.PledgeCollateral.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.QualityAdjPowerSmoothed (smoothing.FilterEstimate) (struct)
+	if err := t.QualityAdjPowerSmoothed.MarshalCBOR(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *CurrentTotalPowerReturn) UnmarshalCBOR(r io.Reader) error {
+	*t = CurrentTotalPowerReturn{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 4 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.RawBytePower (big.Int) (struct)
+
+	{
+
+		if err := t.RawBytePower.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.RawBytePower: %w", err)
+		}
+
+	}
+	// t.QualityAdjPower (big.Int) (struct)
+
+	{
+
+		if err := t.QualityAdjPower.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.QualityAdjPower: %w", err)
+		}
+
+	}
+	// t.PledgeCollateral (big.Int) (struct)
+
+	{
+
+		if err := t.PledgeCollateral.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.PledgeCollateral: %w", err)
+		}
+
+	}
+	// t.QualityAdjPowerSmoothed (smoothing.FilterEstimate) (struct)
+
+	{
+
+		if err := t.QualityAdjPowerSmoothed.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.QualityAdjPowerSmoothed: %w", err)
+		}
+
+	}
+	return nil
+}
+
+var lengthBufEnrollCronEventParams = []byte{130}
+
+func (t *EnrollCronEventParams) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufEnrollCronEventParams); err != nil {
+		return err
+	}
+
+	scratch := make([]byte, 9)
+
+	// t.EventEpoch (abi.ChainEpoch) (int64)
+	if t.EventEpoch >= 0 {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.EventEpoch)); err != nil {
+			return err
+		}
+	} else {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.EventEpoch-1)); err != nil {
+			return err
+		}
+	}
+
+	// t.Payload ([]uint8) (slice)
+	if len(t.Payload) > cbg.ByteArrayMaxLen {
+		return xerrors.Errorf("Byte array in field t.Payload was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(t.Payload))); err != nil {
+		return err
+	}
+
+	if _, err := w.Write(t.Payload[:]); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *EnrollCronEventParams) UnmarshalCBOR(r io.Reader) error {
+	*t = EnrollCronEventParams{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 2 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.EventEpoch (abi.ChainEpoch) (int64)
+	{
+		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+		var extraI int64
+		if err != nil {
+			return err
+		}
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative oveflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.EventEpoch = abi.ChainEpoch(extraI)
+	}
+	// t.Payload ([]uint8) (slice)
+
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.ByteArrayMaxLen {
+		return fmt.Errorf("t.Payload: byte array too large (%d)", extra)
+	}
+	if maj != cbg.MajByteString {
+		return fmt.Errorf("expected byte array")
+	}
+
+	if extra > 0 {
+		t.Payload = make([]uint8, extra)
+	}
+
+	if _, err := io.ReadFull(br, t.Payload[:]); err != nil {
+		return err
 	}
 	return nil
 }

--- a/builtin/v8/power/methods.go
+++ b/builtin/v8/power/methods.go
@@ -12,7 +12,7 @@ var Methods = []interface{}{
 	4: *new(func(interface{}, *EnrollCronEventParams) *abi.EmptyValue),    // EnrollCronEvent
 	5: *new(func(interface{}, *abi.EmptyValue) *abi.EmptyValue),           // CronTick
 	6: *new(func(interface{}, *abi.TokenAmount) *abi.EmptyValue),          // UpdatePledgeTotal
-	// 7: DEPRECATED
+	7: nil,
 	8: *new(func(interface{}, *proof.SealVerifyInfo) *abi.EmptyValue),    // SubmitPoRepForBulkVerify
 	9: *new(func(interface{}, *abi.EmptyValue) *CurrentTotalPowerReturn), // CurrentTotalPower
 }

--- a/builtin/v8/reward/cbor_gen.go
+++ b/builtin/v8/reward/cbor_gen.go
@@ -246,3 +246,179 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 	}
 	return nil
 }
+
+var lengthBufThisEpochRewardReturn = []byte{130}
+
+func (t *ThisEpochRewardReturn) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufThisEpochRewardReturn); err != nil {
+		return err
+	}
+
+	// t.ThisEpochRewardSmoothed (smoothing.FilterEstimate) (struct)
+	if err := t.ThisEpochRewardSmoothed.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.ThisEpochBaselinePower (big.Int) (struct)
+	if err := t.ThisEpochBaselinePower.MarshalCBOR(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *ThisEpochRewardReturn) UnmarshalCBOR(r io.Reader) error {
+	*t = ThisEpochRewardReturn{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 2 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.ThisEpochRewardSmoothed (smoothing.FilterEstimate) (struct)
+
+	{
+
+		if err := t.ThisEpochRewardSmoothed.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.ThisEpochRewardSmoothed: %w", err)
+		}
+
+	}
+	// t.ThisEpochBaselinePower (big.Int) (struct)
+
+	{
+
+		if err := t.ThisEpochBaselinePower.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.ThisEpochBaselinePower: %w", err)
+		}
+
+	}
+	return nil
+}
+
+var lengthBufAwardBlockRewardParams = []byte{132}
+
+func (t *AwardBlockRewardParams) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufAwardBlockRewardParams); err != nil {
+		return err
+	}
+
+	scratch := make([]byte, 9)
+
+	// t.Miner (address.Address) (struct)
+	if err := t.Miner.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.Penalty (big.Int) (struct)
+	if err := t.Penalty.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.GasReward (big.Int) (struct)
+	if err := t.GasReward.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.WinCount (int64) (int64)
+	if t.WinCount >= 0 {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.WinCount)); err != nil {
+			return err
+		}
+	} else {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.WinCount-1)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *AwardBlockRewardParams) UnmarshalCBOR(r io.Reader) error {
+	*t = AwardBlockRewardParams{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 4 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.Miner (address.Address) (struct)
+
+	{
+
+		if err := t.Miner.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.Miner: %w", err)
+		}
+
+	}
+	// t.Penalty (big.Int) (struct)
+
+	{
+
+		if err := t.Penalty.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.Penalty: %w", err)
+		}
+
+	}
+	// t.GasReward (big.Int) (struct)
+
+	{
+
+		if err := t.GasReward.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.GasReward: %w", err)
+		}
+
+	}
+	// t.WinCount (int64) (int64)
+	{
+		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+		var extraI int64
+		if err != nil {
+			return err
+		}
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative oveflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.WinCount = int64(extraI)
+	}
+	return nil
+}

--- a/builtin/v9/gen/gen.go
+++ b/builtin/v9/gen/gen.go
@@ -105,6 +105,11 @@ func main() {
 		power.State{},
 		power.Claim{},
 		// method params and returns
+		power.UpdateClaimedPowerParams{},
+		power.MinerConstructorParams{},
+		power.CreateMinerReturn{},
+		power.CurrentTotalPowerReturn{},
+		power.EnrollCronEventParams{},
 	); err != nil {
 		panic(err)
 	}

--- a/builtin/v9/gen/gen.go
+++ b/builtin/v9/gen/gen.go
@@ -59,6 +59,8 @@ func main() {
 		// actor state
 		reward.State{},
 		// method params and returns
+		reward.ThisEpochRewardReturn{},
+		reward.AwardBlockRewardParams{},
 	); err != nil {
 		panic(err)
 	}

--- a/builtin/v9/init/cbor_gen.go
+++ b/builtin/v9/init/cbor_gen.go
@@ -13,7 +13,7 @@ import (
 
 var _ = xerrors.Errorf
 
-var lengthBufState = []byte{132}
+var lengthBufState = []byte{131}
 
 func (t *State) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -49,13 +49,6 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 	if _, err := io.WriteString(w, string(t.NetworkName)); err != nil {
 		return err
 	}
-
-	// t.InstalledActors (cid.Cid) (struct)
-
-	if err := cbg.WriteCidBuf(scratch, w, t.InstalledActors); err != nil {
-		return xerrors.Errorf("failed to write cid field t.InstalledActors: %w", err)
-	}
-
 	return nil
 }
 
@@ -73,7 +66,7 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 4 {
+	if extra != 3 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -112,18 +105,6 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		}
 
 		t.NetworkName = string(sval)
-	}
-	// t.InstalledActors (cid.Cid) (struct)
-
-	{
-
-		c, err := cbg.ReadCid(br)
-		if err != nil {
-			return xerrors.Errorf("failed to read cid field t.InstalledActors: %w", err)
-		}
-
-		t.InstalledActors = c
-
 	}
 	return nil
 }

--- a/builtin/v9/init/init_actor_state.go
+++ b/builtin/v9/init/init_actor_state.go
@@ -1,7 +1,6 @@
 package init
 
 import (
-	"context"
 	"fmt"
 	"io"
 
@@ -15,10 +14,9 @@ import (
 )
 
 type State struct {
-	AddressMap      cid.Cid // HAMT[addr.Address]abi.ActorID
-	NextID          abi.ActorID
-	NetworkName     string
-	InstalledActors cid.Cid
+	AddressMap  cid.Cid // HAMT[addr.Address]abi.ActorID
+	NextID      abi.ActorID
+	NetworkName string
 }
 
 func ConstructState(store adt.Store, networkName string) (*State, error) {
@@ -27,16 +25,10 @@ func ConstructState(store adt.Store, networkName string) (*State, error) {
 		return nil, xerrors.Errorf("failed to create empty map: %w", err)
 	}
 
-	emptyInstalledActors, err := store.Put(context.TODO(), &InstalledActors{})
-	if err != nil {
-		return nil, xerrors.Errorf("failed to create empty manifest: %w", err)
-	}
-
 	return &State{
-		AddressMap:      emptyAddressMapCid,
-		NextID:          abi.ActorID(builtin.FirstNonSingletonActorId),
-		NetworkName:     networkName,
-		InstalledActors: emptyInstalledActors,
+		AddressMap:  emptyAddressMapCid,
+		NextID:      abi.ActorID(builtin.FirstNonSingletonActorId),
+		NetworkName: networkName,
 	}, nil
 }
 

--- a/builtin/v9/market/cbor_gen.go
+++ b/builtin/v9/market/cbor_gen.go
@@ -1553,7 +1553,7 @@ func (t *ClientDealProposal) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-var lengthBufSectorDeals = []byte{130}
+var lengthBufSectorDeals = []byte{131}
 
 func (t *SectorDeals) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -1565,6 +1565,17 @@ func (t *SectorDeals) MarshalCBOR(w io.Writer) error {
 	}
 
 	scratch := make([]byte, 9)
+
+	// t.SectorType (abi.RegisteredSealProof) (int64)
+	if t.SectorType >= 0 {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.SectorType)); err != nil {
+			return err
+		}
+	} else {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.SectorType-1)); err != nil {
+			return err
+		}
+	}
 
 	// t.SectorExpiry (abi.ChainEpoch) (int64)
 	if t.SectorExpiry >= 0 {
@@ -1607,10 +1618,35 @@ func (t *SectorDeals) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 2 {
+	if extra != 3 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
+	// t.SectorType (abi.RegisteredSealProof) (int64)
+	{
+		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+		var extraI int64
+		if err != nil {
+			return err
+		}
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative oveflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.SectorType = abi.RegisteredSealProof(extraI)
+	}
 	// t.SectorExpiry (abi.ChainEpoch) (int64)
 	{
 		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)

--- a/builtin/v9/market/market_types.go
+++ b/builtin/v9/market/market_types.go
@@ -29,6 +29,7 @@ type VerifyDealsForActivationParams struct {
 }
 
 type SectorDeals struct {
+	SectorType   abi.RegisteredSealProof
 	SectorExpiry abi.ChainEpoch
 	DealIDs      []abi.DealID
 }

--- a/builtin/v9/miner/cbor_gen.go
+++ b/builtin/v9/miner/cbor_gen.go
@@ -349,21 +349,6 @@ func (t *MinerInfo) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.Beneficiary (address.Address) (struct)
-	if err := t.Beneficiary.MarshalCBOR(w); err != nil {
-		return err
-	}
-
-	// t.BeneficiaryTerm (miner.BeneficiaryTerm) (struct)
-	if err := t.BeneficiaryTerm.MarshalCBOR(w); err != nil {
-		return err
-	}
-
-	// t.PendingBeneficiaryTerm (miner.PendingBeneficiaryChange) (struct)
-	if err := t.PendingBeneficiaryTerm.MarshalCBOR(w); err != nil {
-		return err
-	}
-
 	// t.ControlAddresses ([]address.Address) (slice)
 	if len(t.ControlAddresses) > cbg.MaxLength {
 		return xerrors.Errorf("Slice value in field t.ControlAddresses was too long")
@@ -456,6 +441,21 @@ func (t *MinerInfo) MarshalCBOR(w io.Writer) error {
 	if err := t.PendingOwnerAddress.MarshalCBOR(w); err != nil {
 		return err
 	}
+
+	// t.Beneficiary (address.Address) (struct)
+	if err := t.Beneficiary.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.BeneficiaryTerm (miner.BeneficiaryTerm) (struct)
+	if err := t.BeneficiaryTerm.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.PendingBeneficiaryTerm (miner.PendingBeneficiaryChange) (struct)
+	if err := t.PendingBeneficiaryTerm.MarshalCBOR(w); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -492,43 +492,6 @@ func (t *MinerInfo) UnmarshalCBOR(r io.Reader) error {
 
 		if err := t.Worker.UnmarshalCBOR(br); err != nil {
 			return xerrors.Errorf("unmarshaling t.Worker: %w", err)
-		}
-
-	}
-	// t.Beneficiary (address.Address) (struct)
-
-	{
-
-		if err := t.Beneficiary.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.Beneficiary: %w", err)
-		}
-
-	}
-	// t.BeneficiaryTerm (miner.BeneficiaryTerm) (struct)
-
-	{
-
-		if err := t.BeneficiaryTerm.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.BeneficiaryTerm: %w", err)
-		}
-
-	}
-	// t.PendingBeneficiaryTerm (miner.PendingBeneficiaryChange) (struct)
-
-	{
-
-		b, err := br.ReadByte()
-		if err != nil {
-			return err
-		}
-		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
-				return err
-			}
-			t.PendingBeneficiaryTerm = new(PendingBeneficiaryChange)
-			if err := t.PendingBeneficiaryTerm.UnmarshalCBOR(br); err != nil {
-				return xerrors.Errorf("unmarshaling t.PendingBeneficiaryTerm pointer: %w", err)
-			}
 		}
 
 	}
@@ -741,6 +704,43 @@ func (t *MinerInfo) UnmarshalCBOR(r io.Reader) error {
 			t.PendingOwnerAddress = new(address.Address)
 			if err := t.PendingOwnerAddress.UnmarshalCBOR(br); err != nil {
 				return xerrors.Errorf("unmarshaling t.PendingOwnerAddress pointer: %w", err)
+			}
+		}
+
+	}
+	// t.Beneficiary (address.Address) (struct)
+
+	{
+
+		if err := t.Beneficiary.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.Beneficiary: %w", err)
+		}
+
+	}
+	// t.BeneficiaryTerm (miner.BeneficiaryTerm) (struct)
+
+	{
+
+		if err := t.BeneficiaryTerm.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.BeneficiaryTerm: %w", err)
+		}
+
+	}
+	// t.PendingBeneficiaryTerm (miner.PendingBeneficiaryChange) (struct)
+
+	{
+
+		b, err := br.ReadByte()
+		if err != nil {
+			return err
+		}
+		if b != cbg.CborNull[0] {
+			if err := br.UnreadByte(); err != nil {
+				return err
+			}
+			t.PendingBeneficiaryTerm = new(PendingBeneficiaryChange)
+			if err := t.PendingBeneficiaryTerm.UnmarshalCBOR(br); err != nil {
+				return xerrors.Errorf("unmarshaling t.PendingBeneficiaryTerm pointer: %w", err)
 			}
 		}
 

--- a/builtin/v9/miner/miner_state.go
+++ b/builtin/v9/miner/miner_state.go
@@ -90,17 +90,6 @@ type MinerInfo struct {
 	// The associated pubkey-type address is used to sign blocks and messages on behalf of this miner.
 	Worker addr.Address // Must be an ID-address.
 
-	// Beneficiary address for this miner.
-	// This is the address that tokens will be withdrawn to
-	Beneficiary addr.Address
-
-	// Beneficiary's withdrawal quota, how much of the quota has been withdrawn,
-	// and when the Beneficiary expires.
-	BeneficiaryTerm BeneficiaryTerm
-
-	// A proposed change to `BenificiaryTerm`
-	PendingBeneficiaryTerm *PendingBeneficiaryChange
-
 	// Additional addresses that are permitted to submit messages controlling this actor (optional).
 	ControlAddresses []addr.Address // Must all be ID addresses.
 
@@ -132,6 +121,17 @@ type MinerInfo struct {
 	// A proposed new owner account for this miner.
 	// Must be confirmed by a message from the pending address itself.
 	PendingOwnerAddress *addr.Address
+
+	// Beneficiary address for this miner.
+	// This is the address that tokens will be withdrawn to
+	Beneficiary addr.Address
+
+	// Beneficiary's withdrawal quota, how much of the quota has been withdrawn,
+	// and when the Beneficiary expires.
+	BeneficiaryTerm BeneficiaryTerm
+
+	// A proposed change to `BenificiaryTerm`
+	PendingBeneficiaryTerm *PendingBeneficiaryChange
 }
 
 type WorkerKeyChange struct {

--- a/builtin/v9/miner/policy.go
+++ b/builtin/v9/miner/policy.go
@@ -174,3 +174,10 @@ type VestSpec struct {
 	StepDuration abi.ChainEpoch // Duration between successive incremental vests (independent of vesting period).
 	Quantization abi.ChainEpoch // Maximum precision of vesting table (limits cardinality of table).
 }
+
+// Returns maximum achievable QA power.
+func QAPowerMax(size abi.SectorSize) abi.StoragePower {
+	return big.Div(
+		big.Mul(big.NewInt(int64(size)), builtin.VerifiedDealWeightMultiplier),
+		builtin.QualityBaseMultiplier)
+}

--- a/builtin/v9/power/cbor_gen.go
+++ b/builtin/v9/power/cbor_gen.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 
+	address "github.com/filecoin-project/go-address"
 	abi "github.com/filecoin-project/go-state-types/abi"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	xerrors "golang.org/x/xerrors"
@@ -450,6 +451,572 @@ func (t *Claim) UnmarshalCBOR(r io.Reader) error {
 			return xerrors.Errorf("unmarshaling t.QualityAdjPower: %w", err)
 		}
 
+	}
+	return nil
+}
+
+var lengthBufUpdateClaimedPowerParams = []byte{130}
+
+func (t *UpdateClaimedPowerParams) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufUpdateClaimedPowerParams); err != nil {
+		return err
+	}
+
+	// t.RawByteDelta (big.Int) (struct)
+	if err := t.RawByteDelta.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.QualityAdjustedDelta (big.Int) (struct)
+	if err := t.QualityAdjustedDelta.MarshalCBOR(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *UpdateClaimedPowerParams) UnmarshalCBOR(r io.Reader) error {
+	*t = UpdateClaimedPowerParams{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 2 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.RawByteDelta (big.Int) (struct)
+
+	{
+
+		if err := t.RawByteDelta.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.RawByteDelta: %w", err)
+		}
+
+	}
+	// t.QualityAdjustedDelta (big.Int) (struct)
+
+	{
+
+		if err := t.QualityAdjustedDelta.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.QualityAdjustedDelta: %w", err)
+		}
+
+	}
+	return nil
+}
+
+var lengthBufMinerConstructorParams = []byte{134}
+
+func (t *MinerConstructorParams) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufMinerConstructorParams); err != nil {
+		return err
+	}
+
+	scratch := make([]byte, 9)
+
+	// t.OwnerAddr (address.Address) (struct)
+	if err := t.OwnerAddr.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.WorkerAddr (address.Address) (struct)
+	if err := t.WorkerAddr.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.ControlAddrs ([]address.Address) (slice)
+	if len(t.ControlAddrs) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.ControlAddrs was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.ControlAddrs))); err != nil {
+		return err
+	}
+	for _, v := range t.ControlAddrs {
+		if err := v.MarshalCBOR(w); err != nil {
+			return err
+		}
+	}
+
+	// t.WindowPoStProofType (abi.RegisteredPoStProof) (int64)
+	if t.WindowPoStProofType >= 0 {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.WindowPoStProofType)); err != nil {
+			return err
+		}
+	} else {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.WindowPoStProofType-1)); err != nil {
+			return err
+		}
+	}
+
+	// t.PeerId ([]uint8) (slice)
+	if len(t.PeerId) > cbg.ByteArrayMaxLen {
+		return xerrors.Errorf("Byte array in field t.PeerId was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(t.PeerId))); err != nil {
+		return err
+	}
+
+	if _, err := w.Write(t.PeerId[:]); err != nil {
+		return err
+	}
+
+	// t.Multiaddrs ([][]uint8) (slice)
+	if len(t.Multiaddrs) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.Multiaddrs was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Multiaddrs))); err != nil {
+		return err
+	}
+	for _, v := range t.Multiaddrs {
+		if len(v) > cbg.ByteArrayMaxLen {
+			return xerrors.Errorf("Byte array in field v was too long")
+		}
+
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(v))); err != nil {
+			return err
+		}
+
+		if _, err := w.Write(v[:]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *MinerConstructorParams) UnmarshalCBOR(r io.Reader) error {
+	*t = MinerConstructorParams{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 6 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.OwnerAddr (address.Address) (struct)
+
+	{
+
+		if err := t.OwnerAddr.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.OwnerAddr: %w", err)
+		}
+
+	}
+	// t.WorkerAddr (address.Address) (struct)
+
+	{
+
+		if err := t.WorkerAddr.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.WorkerAddr: %w", err)
+		}
+
+	}
+	// t.ControlAddrs ([]address.Address) (slice)
+
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("t.ControlAddrs: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.ControlAddrs = make([]address.Address, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+
+		var v address.Address
+		if err := v.UnmarshalCBOR(br); err != nil {
+			return err
+		}
+
+		t.ControlAddrs[i] = v
+	}
+
+	// t.WindowPoStProofType (abi.RegisteredPoStProof) (int64)
+	{
+		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+		var extraI int64
+		if err != nil {
+			return err
+		}
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative oveflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.WindowPoStProofType = abi.RegisteredPoStProof(extraI)
+	}
+	// t.PeerId ([]uint8) (slice)
+
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.ByteArrayMaxLen {
+		return fmt.Errorf("t.PeerId: byte array too large (%d)", extra)
+	}
+	if maj != cbg.MajByteString {
+		return fmt.Errorf("expected byte array")
+	}
+
+	if extra > 0 {
+		t.PeerId = make([]uint8, extra)
+	}
+
+	if _, err := io.ReadFull(br, t.PeerId[:]); err != nil {
+		return err
+	}
+	// t.Multiaddrs ([][]uint8) (slice)
+
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("t.Multiaddrs: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.Multiaddrs = make([][]uint8, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+
+			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+
+			if extra > cbg.ByteArrayMaxLen {
+				return fmt.Errorf("t.Multiaddrs[i]: byte array too large (%d)", extra)
+			}
+			if maj != cbg.MajByteString {
+				return fmt.Errorf("expected byte array")
+			}
+
+			if extra > 0 {
+				t.Multiaddrs[i] = make([]uint8, extra)
+			}
+
+			if _, err := io.ReadFull(br, t.Multiaddrs[i][:]); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+var lengthBufCreateMinerReturn = []byte{130}
+
+func (t *CreateMinerReturn) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufCreateMinerReturn); err != nil {
+		return err
+	}
+
+	// t.IDAddress (address.Address) (struct)
+	if err := t.IDAddress.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.RobustAddress (address.Address) (struct)
+	if err := t.RobustAddress.MarshalCBOR(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *CreateMinerReturn) UnmarshalCBOR(r io.Reader) error {
+	*t = CreateMinerReturn{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 2 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.IDAddress (address.Address) (struct)
+
+	{
+
+		if err := t.IDAddress.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.IDAddress: %w", err)
+		}
+
+	}
+	// t.RobustAddress (address.Address) (struct)
+
+	{
+
+		if err := t.RobustAddress.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.RobustAddress: %w", err)
+		}
+
+	}
+	return nil
+}
+
+var lengthBufCurrentTotalPowerReturn = []byte{132}
+
+func (t *CurrentTotalPowerReturn) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufCurrentTotalPowerReturn); err != nil {
+		return err
+	}
+
+	// t.RawBytePower (big.Int) (struct)
+	if err := t.RawBytePower.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.QualityAdjPower (big.Int) (struct)
+	if err := t.QualityAdjPower.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.PledgeCollateral (big.Int) (struct)
+	if err := t.PledgeCollateral.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.QualityAdjPowerSmoothed (smoothing.FilterEstimate) (struct)
+	if err := t.QualityAdjPowerSmoothed.MarshalCBOR(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *CurrentTotalPowerReturn) UnmarshalCBOR(r io.Reader) error {
+	*t = CurrentTotalPowerReturn{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 4 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.RawBytePower (big.Int) (struct)
+
+	{
+
+		if err := t.RawBytePower.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.RawBytePower: %w", err)
+		}
+
+	}
+	// t.QualityAdjPower (big.Int) (struct)
+
+	{
+
+		if err := t.QualityAdjPower.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.QualityAdjPower: %w", err)
+		}
+
+	}
+	// t.PledgeCollateral (big.Int) (struct)
+
+	{
+
+		if err := t.PledgeCollateral.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.PledgeCollateral: %w", err)
+		}
+
+	}
+	// t.QualityAdjPowerSmoothed (smoothing.FilterEstimate) (struct)
+
+	{
+
+		if err := t.QualityAdjPowerSmoothed.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.QualityAdjPowerSmoothed: %w", err)
+		}
+
+	}
+	return nil
+}
+
+var lengthBufEnrollCronEventParams = []byte{130}
+
+func (t *EnrollCronEventParams) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufEnrollCronEventParams); err != nil {
+		return err
+	}
+
+	scratch := make([]byte, 9)
+
+	// t.EventEpoch (abi.ChainEpoch) (int64)
+	if t.EventEpoch >= 0 {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.EventEpoch)); err != nil {
+			return err
+		}
+	} else {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.EventEpoch-1)); err != nil {
+			return err
+		}
+	}
+
+	// t.Payload ([]uint8) (slice)
+	if len(t.Payload) > cbg.ByteArrayMaxLen {
+		return xerrors.Errorf("Byte array in field t.Payload was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(t.Payload))); err != nil {
+		return err
+	}
+
+	if _, err := w.Write(t.Payload[:]); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *EnrollCronEventParams) UnmarshalCBOR(r io.Reader) error {
+	*t = EnrollCronEventParams{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 2 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.EventEpoch (abi.ChainEpoch) (int64)
+	{
+		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+		var extraI int64
+		if err != nil {
+			return err
+		}
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative oveflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.EventEpoch = abi.ChainEpoch(extraI)
+	}
+	// t.Payload ([]uint8) (slice)
+
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.ByteArrayMaxLen {
+		return fmt.Errorf("t.Payload: byte array too large (%d)", extra)
+	}
+	if maj != cbg.MajByteString {
+		return fmt.Errorf("expected byte array")
+	}
+
+	if extra > 0 {
+		t.Payload = make([]uint8, extra)
+	}
+
+	if _, err := io.ReadFull(br, t.Payload[:]); err != nil {
+		return err
 	}
 	return nil
 }

--- a/builtin/v9/power/methods.go
+++ b/builtin/v9/power/methods.go
@@ -12,7 +12,7 @@ var Methods = []interface{}{
 	4: *new(func(interface{}, *EnrollCronEventParams) *abi.EmptyValue),    // EnrollCronEvent
 	5: *new(func(interface{}, *abi.EmptyValue) *abi.EmptyValue),           // CronTick
 	6: *new(func(interface{}, *abi.TokenAmount) *abi.EmptyValue),          // UpdatePledgeTotal
-	// 7: DEPRECATED
+	7: nil,
 	8: *new(func(interface{}, *proof.SealVerifyInfo) *abi.EmptyValue),    // SubmitPoRepForBulkVerify
 	9: *new(func(interface{}, *abi.EmptyValue) *CurrentTotalPowerReturn), // CurrentTotalPower
 }

--- a/builtin/v9/reward/cbor_gen.go
+++ b/builtin/v9/reward/cbor_gen.go
@@ -246,3 +246,179 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 	}
 	return nil
 }
+
+var lengthBufThisEpochRewardReturn = []byte{130}
+
+func (t *ThisEpochRewardReturn) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufThisEpochRewardReturn); err != nil {
+		return err
+	}
+
+	// t.ThisEpochRewardSmoothed (smoothing.FilterEstimate) (struct)
+	if err := t.ThisEpochRewardSmoothed.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.ThisEpochBaselinePower (big.Int) (struct)
+	if err := t.ThisEpochBaselinePower.MarshalCBOR(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *ThisEpochRewardReturn) UnmarshalCBOR(r io.Reader) error {
+	*t = ThisEpochRewardReturn{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 2 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.ThisEpochRewardSmoothed (smoothing.FilterEstimate) (struct)
+
+	{
+
+		if err := t.ThisEpochRewardSmoothed.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.ThisEpochRewardSmoothed: %w", err)
+		}
+
+	}
+	// t.ThisEpochBaselinePower (big.Int) (struct)
+
+	{
+
+		if err := t.ThisEpochBaselinePower.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.ThisEpochBaselinePower: %w", err)
+		}
+
+	}
+	return nil
+}
+
+var lengthBufAwardBlockRewardParams = []byte{132}
+
+func (t *AwardBlockRewardParams) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufAwardBlockRewardParams); err != nil {
+		return err
+	}
+
+	scratch := make([]byte, 9)
+
+	// t.Miner (address.Address) (struct)
+	if err := t.Miner.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.Penalty (big.Int) (struct)
+	if err := t.Penalty.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.GasReward (big.Int) (struct)
+	if err := t.GasReward.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.WinCount (int64) (int64)
+	if t.WinCount >= 0 {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.WinCount)); err != nil {
+			return err
+		}
+	} else {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.WinCount-1)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *AwardBlockRewardParams) UnmarshalCBOR(r io.Reader) error {
+	*t = AwardBlockRewardParams{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 4 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.Miner (address.Address) (struct)
+
+	{
+
+		if err := t.Miner.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.Miner: %w", err)
+		}
+
+	}
+	// t.Penalty (big.Int) (struct)
+
+	{
+
+		if err := t.Penalty.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.Penalty: %w", err)
+		}
+
+	}
+	// t.GasReward (big.Int) (struct)
+
+	{
+
+		if err := t.GasReward.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.GasReward: %w", err)
+		}
+
+	}
+	// t.WinCount (int64) (int64)
+	{
+		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+		var extraI int64
+		if err != nil {
+			return err
+		}
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative oveflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.WinCount = int64(extraI)
+	}
+	return nil
+}


### PR DESCRIPTION
[fix: v9 init state: remove InstalledActors](https://github.com/filecoin-project/go-state-types/commit/f4ad1a59d916a5e25536b7044368e503e9c16fd5)
- I think this was caused by basing the v9 state off the wrong branch of builtin-actors
 
[fix: v9 market types: add SectorType to SectorDeals](https://github.com/filecoin-project/go-state-types/commit/395c37ab732cccd7a18e7bb3f722c342674755ef)
- Missed in the FIP-0034 integration
 
[Add QAPowerMax method](https://github.com/filecoin-project/go-state-types/commit/6740cdd9390d2a252543527685a3ac51c393087f)
- Needed in clients like Lotus
 
[fix: MinerInfo: move benificiary terms to the right position](https://github.com/filecoin-project/go-state-types/commit/32d4e8d49c0f0cc9857b08449f9f3a9dee51d9b0)
- Bug in the FIP-0029 integration
 
[fix: power methods: set deprecated methods to nil](https://github.com/filecoin-project/go-state-types/commit/299708850800bfdf3556e9876d87875e83713c55)
 
[fix: reward: add missing types to cbor_gen](https://github.com/filecoin-project/go-state-types/commit/52b8c0e2be9236e2b5946b49e755c2e7126fa33a)
 
[fix: power: add missing types to cbor_gen](https://github.com/filecoin-project/go-state-types/commit/916a5a14a31b10aef40d895de960e7276839ae99)