### PR TITLE
fix: Make methods list a map

### DIFF
--- a/builtin/v8/account/methods.go
+++ b/builtin/v8/account/methods.go
@@ -5,7 +5,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 )
 
-var Methods = []interface{}{
+var Methods = map[uint64]interface{}{
 	1: *new(func(interface{}, *address.Address) *abi.EmptyValue), // Constructor
 	2: *new(func(interface{}, *abi.EmptyValue) *address.Address), // PubkeyAddress
 }

--- a/builtin/v8/cron/methods.go
+++ b/builtin/v8/cron/methods.go
@@ -4,7 +4,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 )
 
-var Methods = []interface{}{
+var Methods = map[uint64]interface{}{
 	1: *new(func(interface{}, *ConstructorParams) *abi.EmptyValue), // Constructor
 	2: *new(func(interface{}, *abi.EmptyValue) *abi.EmptyValue),    // EpochTick
 }

--- a/builtin/v8/init/methods.go
+++ b/builtin/v8/init/methods.go
@@ -4,7 +4,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 )
 
-var Methods = []interface{}{
+var Methods = map[uint64]interface{}{
 	1: *new(func(interface{}, *ConstructorParams) *abi.EmptyValue), // Constructor
 	2: *new(func(interface{}, *ExecParams) *ExecReturn),            // Exec
 }

--- a/builtin/v8/market/methods.go
+++ b/builtin/v8/market/methods.go
@@ -5,7 +5,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 )
 
-var Methods = []interface{}{
+var Methods = map[uint64]interface{}{
 	1: *new(func(interface{}, *abi.EmptyValue) *abi.EmptyValue),                                 // Constructor
 	2: *new(func(interface{}, *address.Address) *abi.EmptyValue),                                // AddBalance
 	3: *new(func(interface{}, *WithdrawBalanceParams) *abi.TokenAmount),                         // WithdrawBalance

--- a/builtin/v8/miner/methods.go
+++ b/builtin/v8/miner/methods.go
@@ -7,7 +7,7 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin/v8/power"
 )
 
-var Methods = []interface{}{
+var Methods = map[uint64]interface{}{
 	1:  *new(func(interface{}, *power.MinerConstructorParams) *abi.EmptyValue),   // Constructor
 	2:  *new(func(interface{}, *abi.EmptyValue) *GetControlAddressesReturn),      // ControlAddresses
 	3:  *new(func(interface{}, *ChangeWorkerAddressParams) *abi.EmptyValue),      // ChangeWorkerAddress

--- a/builtin/v8/multisig/methods.go
+++ b/builtin/v8/multisig/methods.go
@@ -4,7 +4,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 )
 
-var Methods = []interface{}{
+var Methods = map[uint64]interface{}{
 	1: *new(func(interface{}, *ConstructorParams) *abi.EmptyValue),                 // Constructor
 	2: *new(func(interface{}, *ProposeParams) *ProposeReturn),                      // Propose
 	3: *new(func(interface{}, *TxnIDParams) *ApproveReturn),                        // Approve

--- a/builtin/v8/paych/methods.go
+++ b/builtin/v8/paych/methods.go
@@ -4,7 +4,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 )
 
-var Methods = []interface{}{
+var Methods = map[uint64]interface{}{
 	1: *new(func(interface{}, *ConstructorParams) *abi.EmptyValue),        // Constructor
 	2: *new(func(interface{}, *UpdateChannelStateParams) *abi.EmptyValue), // UpdateChannelState
 	3: *new(func(interface{}, *abi.EmptyValue) *abi.EmptyValue),           // Settle

--- a/builtin/v8/power/methods.go
+++ b/builtin/v8/power/methods.go
@@ -5,7 +5,7 @@ import (
 	"github.com/filecoin-project/go-state-types/proof"
 )
 
-var Methods = []interface{}{
+var Methods = map[uint64]interface{}{
 	1: *new(func(interface{}, *abi.EmptyValue) *abi.EmptyValue),           // Constructor
 	2: *new(func(interface{}, *CreateMinerParams) *CreateMinerReturn),     // CreateMiner
 	3: *new(func(interface{}, *UpdateClaimedPowerParams) *abi.EmptyValue), // UpdateClaimedPower

--- a/builtin/v8/reward/methods.go
+++ b/builtin/v8/reward/methods.go
@@ -4,7 +4,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 )
 
-var Methods = []interface{}{
+var Methods = map[uint64]interface{}{
 	1: *new(func(interface{}, *abi.StoragePower) *abi.EmptyValue),       // Constructor
 	2: *new(func(interface{}, *AwardBlockRewardParams) *abi.EmptyValue), // AwardBlockReward
 	3: *new(func(interface{}, *abi.EmptyValue) *ThisEpochRewardReturn),  // ThisEpochReward

--- a/builtin/v8/system/methods.go
+++ b/builtin/v8/system/methods.go
@@ -4,6 +4,6 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 )
 
-var Methods = []interface{}{
+var Methods = map[uint64]interface{}{
 	1: *new(func(interface{}, *abi.EmptyValue) *abi.EmptyValue), // Constructor
 }

--- a/builtin/v8/verifreg/methods.go
+++ b/builtin/v8/verifreg/methods.go
@@ -5,7 +5,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 )
 
-var Methods = []interface{}{
+var Methods = map[uint64]interface{}{
 	1: *new(func(interface{}, *address.Address) *abi.EmptyValue),          // Constructor
 	2: *new(func(interface{}, *AddVerifierParams) *abi.EmptyValue),        // AddVerifier
 	3: *new(func(interface{}, *address.Address) *abi.EmptyValue),          // RemoveVerifier

--- a/builtin/v9/account/methods.go
+++ b/builtin/v9/account/methods.go
@@ -5,7 +5,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 )
 
-var Methods = []interface{}{
+var Methods = map[uint64]interface{}{
 	1: *new(func(interface{}, *address.Address) *abi.EmptyValue),           // Constructor
 	2: *new(func(interface{}, *abi.EmptyValue) *address.Address),           // PubkeyAddress
 	3: *new(func(interface{}, *AuthenticateMessageParams) *abi.EmptyValue), // AuthenticateMessage

--- a/builtin/v9/cron/methods.go
+++ b/builtin/v9/cron/methods.go
@@ -4,7 +4,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 )
 
-var Methods = []interface{}{
+var Methods = map[uint64]interface{}{
 	1: *new(func(interface{}, *ConstructorParams) *abi.EmptyValue), // Constructor
 	2: *new(func(interface{}, *abi.EmptyValue) *abi.EmptyValue),    // EpochTick
 }

--- a/builtin/v9/init/methods.go
+++ b/builtin/v9/init/methods.go
@@ -4,7 +4,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 )
 
-var Methods = []interface{}{
+var Methods = map[uint64]interface{}{
 	1: *new(func(interface{}, *ConstructorParams) *abi.EmptyValue), // Constructor
 	2: *new(func(interface{}, *ExecParams) *ExecReturn),            // Exec
 }

--- a/builtin/v9/market/methods.go
+++ b/builtin/v9/market/methods.go
@@ -5,7 +5,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 )
 
-var Methods = []interface{}{
+var Methods = map[uint64]interface{}{
 	1: *new(func(interface{}, *abi.EmptyValue) *abi.EmptyValue),                                 // Constructor
 	2: *new(func(interface{}, *address.Address) *abi.EmptyValue),                                // AddBalance
 	3: *new(func(interface{}, *WithdrawBalanceParams) *abi.TokenAmount),                         // WithdrawBalance

--- a/builtin/v9/miner/methods.go
+++ b/builtin/v9/miner/methods.go
@@ -7,7 +7,7 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin/v9/power"
 )
 
-var Methods = []interface{}{
+var Methods = map[uint64]interface{}{
 	1:  *new(func(interface{}, *power.MinerConstructorParams) *abi.EmptyValue),   // Constructor
 	2:  *new(func(interface{}, *abi.EmptyValue) *GetControlAddressesReturn),      // ControlAddresses
 	3:  *new(func(interface{}, *ChangeWorkerAddressParams) *abi.EmptyValue),      // ChangeWorkerAddress

--- a/builtin/v9/multisig/methods.go
+++ b/builtin/v9/multisig/methods.go
@@ -4,7 +4,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 )
 
-var Methods = []interface{}{
+var Methods = map[uint64]interface{}{
 	1: *new(func(interface{}, *ConstructorParams) *abi.EmptyValue),                 // Constructor
 	2: *new(func(interface{}, *ProposeParams) *ProposeReturn),                      // Propose
 	3: *new(func(interface{}, *TxnIDParams) *ApproveReturn),                        // Approve

--- a/builtin/v9/paych/methods.go
+++ b/builtin/v9/paych/methods.go
@@ -4,7 +4,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 )
 
-var Methods = []interface{}{
+var Methods = map[uint64]interface{}{
 	1: *new(func(interface{}, *ConstructorParams) *abi.EmptyValue),        // Constructor
 	2: *new(func(interface{}, *UpdateChannelStateParams) *abi.EmptyValue), // UpdateChannelState
 	3: *new(func(interface{}, *abi.EmptyValue) *abi.EmptyValue),           // Settle

--- a/builtin/v9/power/methods.go
+++ b/builtin/v9/power/methods.go
@@ -5,7 +5,7 @@ import (
 	"github.com/filecoin-project/go-state-types/proof"
 )
 
-var Methods = []interface{}{
+var Methods = map[uint64]interface{}{
 	1: *new(func(interface{}, *abi.EmptyValue) *abi.EmptyValue),           // Constructor
 	2: *new(func(interface{}, *CreateMinerParams) *CreateMinerReturn),     // CreateMiner
 	3: *new(func(interface{}, *UpdateClaimedPowerParams) *abi.EmptyValue), // UpdateClaimedPower

--- a/builtin/v9/reward/methods.go
+++ b/builtin/v9/reward/methods.go
@@ -4,7 +4,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 )
 
-var Methods = []interface{}{
+var Methods = map[uint64]interface{}{
 	1: *new(func(interface{}, *abi.StoragePower) *abi.EmptyValue),       // Constructor
 	2: *new(func(interface{}, *AwardBlockRewardParams) *abi.EmptyValue), // AwardBlockReward
 	3: *new(func(interface{}, *abi.EmptyValue) *ThisEpochRewardReturn),  // ThisEpochReward

--- a/builtin/v9/system/methods.go
+++ b/builtin/v9/system/methods.go
@@ -4,6 +4,6 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 )
 
-var Methods = []interface{}{
+var Methods = map[uint64]interface{}{
 	1: *new(func(interface{}, *abi.EmptyValue) *abi.EmptyValue), // Constructor
 }

--- a/builtin/v9/verifreg/methods.go
+++ b/builtin/v9/verifreg/methods.go
@@ -5,7 +5,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 )
 
-var Methods = []interface{}{
+var Methods = map[uint64]interface{}{
 	1: *new(func(interface{}, *address.Address) *abi.EmptyValue),          // Constructor
 	2: *new(func(interface{}, *AddVerifierParams) *abi.EmptyValue),        // AddVerifier
 	3: *new(func(interface{}, *address.Address) *abi.EmptyValue),          // RemoveVerifier


### PR DESCRIPTION
Verifreg in actors v9 has one method with a very large method num. Cbor-gen runs out of memory trying to deal with a slice with that index, so we're making the methods structs a map.