### PR TITLE
feat: crypto: add SigType: SigTypeDelegated

### DIFF
--- a/crypto/signature.go
+++ b/crypto/signature.go
@@ -16,7 +16,7 @@ const (
 
 	SigTypeSecp256k1 = SigType(iota)
 	SigTypeBLS
-	SigTypeEthSecp256k1
+	SigTypeDelegated
 )
 
 func (t SigType) Name() (string, error) {
@@ -27,7 +27,7 @@ func (t SigType) Name() (string, error) {
 		return "secp256k1", nil
 	case SigTypeBLS:
 		return "bls", nil
-	case SigTypeEthSecp256k1:
+	case SigTypeDelegated:
 		return "ethsecp256k1", nil
 	default:
 		return "", fmt.Errorf("invalid signature type: %d", t)
@@ -93,8 +93,8 @@ func (s *Signature) UnmarshalCBOR(br io.Reader) error {
 		s.Type = SigTypeSecp256k1
 	case SigTypeBLS:
 		s.Type = SigTypeBLS
-	case SigTypeEthSecp256k1:
-		s.Type = SigTypeEthSecp256k1
+	case SigTypeDelegated:
+		s.Type = SigTypeDelegated
 	}
 	s.Data = buf[1:]
 	return nil
@@ -124,8 +124,8 @@ func (s *Signature) UnmarshalBinary(bs []byte) error {
 		s.Type = SigTypeSecp256k1
 	case SigTypeBLS:
 		s.Type = SigTypeBLS
-	case SigTypeEthSecp256k1:
-		s.Type = SigTypeEthSecp256k1
+	case SigTypeDelegated:
+		s.Type = SigTypeDelegated
 	}
 	s.Data = bs[1:]
 	return nil

--- a/crypto/signature.go
+++ b/crypto/signature.go
@@ -16,6 +16,7 @@ const (
 
 	SigTypeSecp256k1 = SigType(iota)
 	SigTypeBLS
+	SigTypeEthSecp256k1
 )
 
 func (t SigType) Name() (string, error) {
@@ -26,6 +27,8 @@ func (t SigType) Name() (string, error) {
 		return "secp256k1", nil
 	case SigTypeBLS:
 		return "bls", nil
+	case SigTypeEthSecp256k1:
+		return "ethsecp256k1", nil
 	default:
 		return "", fmt.Errorf("invalid signature type: %d", t)
 	}
@@ -90,6 +93,8 @@ func (s *Signature) UnmarshalCBOR(br io.Reader) error {
 		s.Type = SigTypeSecp256k1
 	case SigTypeBLS:
 		s.Type = SigTypeBLS
+	case SigTypeEthSecp256k1:
+		s.Type = SigTypeEthSecp256k1
 	}
 	s.Data = buf[1:]
 	return nil
@@ -119,6 +124,8 @@ func (s *Signature) UnmarshalBinary(bs []byte) error {
 		s.Type = SigTypeSecp256k1
 	case SigTypeBLS:
 		s.Type = SigTypeBLS
+	case SigTypeEthSecp256k1:
+		s.Type = SigTypeEthSecp256k1
 	}
 	s.Data = bs[1:]
 	return nil

--- a/crypto/signature.go
+++ b/crypto/signature.go
@@ -28,7 +28,7 @@ func (t SigType) Name() (string, error) {
 	case SigTypeBLS:
 		return "bls", nil
 	case SigTypeDelegated:
-		return "ethsecp256k1", nil
+		return "delegated", nil
 	default:
 		return "", fmt.Errorf("invalid signature type: %d", t)
 	}


### PR DESCRIPTION
A new SigType is required for sig.Verify to check the signature signed by Ethereum's clients. The reason we can't use existing SigTypeSecp256k1 is that its verifier uses blake2b to hash the message, but SigTypeDelegated's verifier should use keccak256 to hash the message, so we need a new SigType to distinguish them. 