### PR TITLE
FIP-0045: Implement migrations

### DIFF
--- a/builtin/shared.go
+++ b/builtin/shared.go
@@ -10,6 +10,8 @@ import (
 // This value has been empirically chosen, but the optimal value for maps with different mutation profiles may differ.
 const DefaultHamtBitwidth = 5
 
+const DefaultTokenActorBitwidth = 3
+
 type BigFrac struct {
 	Numerator   big.Int
 	Denominator big.Int

--- a/builtin/v8/miner/deadline_state.go
+++ b/builtin/v8/miner/deadline_state.go
@@ -96,8 +96,55 @@ const DeadlineExpirationAmtBitwidth = 5
 const DeadlineOptimisticPoStSubmissionsAmtBitwidth = 2
 
 //
+// Deadline (singular)
+//
+
+func ConstructDeadline(store adt.Store) (*Deadline, error) {
+	emptyPartitionsArrayCid, err := adt.StoreEmptyArray(store, DeadlinePartitionsAmtBitwidth)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to construct empty partitions array: %w", err)
+	}
+	emptyDeadlineExpirationArrayCid, err := adt.StoreEmptyArray(store, DeadlineExpirationAmtBitwidth)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to construct empty deadline expiration array: %w", err)
+	}
+
+	emptySectorsSnapshotArrayCid, err := adt.StoreEmptyArray(store, SectorsAmtBitwidth)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to construct empty sectors snapshot array: %w", err)
+	}
+
+	emptyPoStSubmissionsArrayCid, err := adt.StoreEmptyArray(store, DeadlineOptimisticPoStSubmissionsAmtBitwidth)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to construct empty proofs array: %w", err)
+	}
+
+	return &Deadline{
+		Partitions:                        emptyPartitionsArrayCid,
+		ExpirationsEpochs:                 emptyDeadlineExpirationArrayCid,
+		EarlyTerminations:                 bitfield.New(),
+		LiveSectors:                       0,
+		TotalSectors:                      0,
+		FaultyPower:                       NewPowerPairZero(),
+		PartitionsPoSted:                  bitfield.New(),
+		OptimisticPoStSubmissions:         emptyPoStSubmissionsArrayCid,
+		PartitionsSnapshot:                emptyPartitionsArrayCid,
+		SectorsSnapshot:                   emptySectorsSnapshotArrayCid,
+		OptimisticPoStSubmissionsSnapshot: emptyPoStSubmissionsArrayCid,
+	}, nil
+}
+
+//
 // Deadlines (plural)
 //
+
+func ConstructDeadlines(emptyDeadlineCid cid.Cid) *Deadlines {
+	d := new(Deadlines)
+	for i := range d.Due {
+		d.Due[i] = emptyDeadlineCid
+	}
+	return d
+}
 
 func (d *Deadlines) LoadDeadline(store adt.Store, dlIdx uint64) (*Deadline, error) {
 	if dlIdx >= uint64(len(d.Due)) {

--- a/builtin/v8/util/adt/set.go
+++ b/builtin/v8/util/adt/set.go
@@ -1,0 +1,71 @@
+package adt
+
+import (
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/ipfs/go-cid"
+)
+
+// Set interprets a Map as a set, storing keys (with empty values) in a HAMT.
+type Set struct {
+	m *Map
+}
+
+// AsSet interprets a store as a HAMT-based set with root `r`.
+// The HAMT is interpreted with branching factor 2^bitwidth.
+func AsSet(s Store, r cid.Cid, bitwidth int) (*Set, error) {
+	m, err := AsMap(s, r, bitwidth)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Set{
+		m: m,
+	}, nil
+}
+
+// NewSet creates a new HAMT with root `r` and store `s`.
+// The HAMT has branching factor 2^bitwidth.
+func MakeEmptySet(s Store, bitwidth int) (*Set, error) {
+	m, err := MakeEmptyMap(s, bitwidth)
+	if err != nil {
+		return nil, err
+	}
+	return &Set{m}, nil
+}
+
+// Root return the root cid of HAMT.
+func (h *Set) Root() (cid.Cid, error) {
+	return h.m.Root()
+}
+
+// Put adds `k` to the set.
+func (h *Set) Put(k abi.Keyer) error {
+	return h.m.Put(k, nil)
+}
+
+// Has returns true iff `k` is in the set.
+func (h *Set) Has(k abi.Keyer) (bool, error) {
+	return h.m.Get(k, nil)
+}
+
+// Removes `k` from the set, if present.
+// Returns whether the key was previously present.
+func (h *Set) TryDelete(k abi.Keyer) (bool, error) {
+	return h.m.TryDelete(k)
+}
+
+// Removes `k` from the set, expecting it to be present.
+func (h *Set) Delete(k abi.Keyer) error {
+	return h.m.Delete(k)
+}
+
+// ForEach iterates over all values in the set, calling the callback for each value.
+// Returning error from the callback stops the iteration.
+func (h *Set) ForEach(cb func(k string) error) error {
+	return h.m.ForEach(nil, cb)
+}
+
+// Collects all the keys from the set into a slice of strings.
+func (h *Set) CollectKeys() (out []string, err error) {
+	return h.m.CollectKeys()
+}

--- a/builtin/v9/datacap/datacap_state.go
+++ b/builtin/v9/datacap/datacap_state.go
@@ -4,13 +4,10 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
-	"github.com/filecoin-project/go-state-types/builtin"
 	"github.com/filecoin-project/go-state-types/builtin/v9/util/adt"
 	"github.com/ipfs/go-cid"
 	"golang.org/x/xerrors"
 )
-
-var DatacapGranularity = builtin.TokenPrecision
 
 type State struct {
 	Governor address.Address

--- a/builtin/v9/datacap/datacap_state.go
+++ b/builtin/v9/datacap/datacap_state.go
@@ -16,8 +16,8 @@ type State struct {
 
 type TokenState struct {
 	Supply       abi.TokenAmount
-	Balances     cid.Cid // HAMT address.Address[abi.TokenAmount]
-	Allowances   cid.Cid // HAMT address.Address[address.Address[abi.TokenAmount]]
+	Balances     cid.Cid // HAMT abi.ActorID[abi.TokenAmount]
+	Allowances   cid.Cid // HAMT abi.ActorID[abi.ActorID[abi.TokenAmount]]
 	HamtBitWidth uint64  // uint32 in builtin-actors. uint64 here to satisfy cbor-gen
 }
 

--- a/builtin/v9/datacap/datacap_types.go
+++ b/builtin/v9/datacap/datacap_types.go
@@ -3,7 +3,11 @@ package datacap
 import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/builtin"
 )
+
+var InfiniteAllowance = big.Mul(big.MustFromString("1000000000000000000000"), builtin.TokenPrecision)
 
 type MintParams struct {
 	To        address.Address

--- a/builtin/v9/market/market_state.go
+++ b/builtin/v9/market/market_state.go
@@ -52,7 +52,7 @@ type State struct {
 	TotalClientStorageFee abi.TokenAmount
 
 	// Verified registry allocation IDs for deals that are not yet activated.
-	PendingDealAllocationIds cid.Cid
+	PendingDealAllocationIds cid.Cid // HAMT[DealID]AllocationID
 }
 
 func ConstructState(store adt.Store) (*State, error) {

--- a/builtin/v9/market/policy.go
+++ b/builtin/v9/market/policy.go
@@ -19,6 +19,8 @@ var DealMinDuration = abi.ChainEpoch(180 * builtin.EpochsInDay) // PARAM_SPEC
 // Maximum deal duration
 var DealMaxDuration = abi.ChainEpoch(540 * builtin.EpochsInDay) // PARAM_SPEC
 
+var MarketDefaultAllocationTermBuffer = abi.ChainEpoch(90 * builtin.EpochsInDay)
+
 // Bounds (inclusive) on deal duration
 func DealDurationBounds(_ abi.PaddedPieceSize) (min abi.ChainEpoch, max abi.ChainEpoch) {
 	return DealMinDuration, DealMaxDuration

--- a/builtin/v9/migration/datacap.go
+++ b/builtin/v9/migration/datacap.go
@@ -1,0 +1,92 @@
+package migration
+
+import (
+	"context"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/builtin"
+	adt8 "github.com/filecoin-project/go-state-types/builtin/v8/util/adt"
+	verifreg8 "github.com/filecoin-project/go-state-types/builtin/v8/verifreg"
+	datacap9 "github.com/filecoin-project/go-state-types/builtin/v9/datacap"
+	adt9 "github.com/filecoin-project/go-state-types/builtin/v9/util/adt"
+	verifreg9 "github.com/filecoin-project/go-state-types/builtin/v9/verifreg"
+	"github.com/ipfs/go-cid"
+	"golang.org/x/xerrors"
+)
+
+func createDatacap(ctx context.Context, adtStore adt8.Store, verifregStateV8 verifreg8.State, emptyMapCid cid.Cid) (cid.Cid, error) {
+
+	verifiedClients, err := adt8.AsMap(adtStore, verifregStateV8.VerifiedClients, builtin.DefaultHamtBitwidth)
+	if err != nil {
+		return cid.Undef, xerrors.Errorf("failed to get verified clients: %w", err)
+	}
+
+	tokenSupply := big.Zero()
+
+	balancesMap, err := adt9.AsMap(adtStore, emptyMapCid, builtin.DefaultHamtBitwidth)
+	if err != nil {
+		return cid.Undef, xerrors.Errorf("failed to load empty map: %w", err)
+	}
+
+	allowancesMap, err := adt9.AsMap(adtStore, emptyMapCid, builtin.DefaultHamtBitwidth)
+	if err != nil {
+		return cid.Undef, xerrors.Errorf("failed to load empty map: %w", err)
+	}
+
+	var dcap abi.StoragePower
+	if err = verifiedClients.ForEach(&dcap, func(key string) error {
+		a, err := address.NewFromBytes([]byte(key))
+		if err != nil {
+			return err
+		}
+
+		tokenAmount := verifreg9.DataCapToTokens(dcap)
+		tokenSupply = big.Add(tokenSupply, tokenAmount)
+		if err = balancesMap.Put(abi.IdAddrKey(a), &tokenAmount); err != nil {
+			return xerrors.Errorf("failed to put new balancesMap entry: %w", err)
+		}
+
+		allowancesMapEntry, err := adt9.AsMap(adtStore, emptyMapCid, builtin.DefaultHamtBitwidth)
+		if err != nil {
+			return xerrors.Errorf("failed to load empty map: %w", err)
+		}
+
+		if err = allowancesMapEntry.Put(abi.IdAddrKey(builtin.StorageMarketActorAddr), &datacap9.InfiniteAllowance); err != nil {
+			return xerrors.Errorf("failed to populate allowance map: %w", err)
+		}
+
+		return allowancesMap.Put(abi.IdAddrKey(a), allowancesMapEntry)
+	}); err != nil {
+		return cid.Undef, xerrors.Errorf("failed to loop over verified clients: %w", err)
+	}
+
+	balancesMapRoot, err := balancesMap.Root()
+	if err != nil {
+		return cid.Undef, xerrors.Errorf("failed to flush balances map: %w", err)
+	}
+
+	allowancesMapRoot, err := allowancesMap.Root()
+	if err != nil {
+		return cid.Undef, xerrors.Errorf("failed to flush allowances map: %w", err)
+	}
+
+	dataCapState := datacap9.State{
+		Governor: builtin.VerifiedRegistryActorAddr,
+		Token: datacap9.TokenState{
+			Supply:       tokenSupply,
+			Balances:     balancesMapRoot,
+			Allowances:   allowancesMapRoot,
+			HamtBitWidth: builtin.DefaultHamtBitwidth,
+		},
+	}
+
+	dataCapHead, err := adtStore.Put(ctx, &dataCapState)
+	if err != nil {
+		return cid.Undef, xerrors.Errorf("failed to put data cap state: %w", err)
+	}
+
+	return dataCapHead, nil
+
+}

--- a/builtin/v9/migration/datacap.go
+++ b/builtin/v9/migration/datacap.go
@@ -55,7 +55,7 @@ func (d *datacapMigrator) migrateState(ctx context.Context, store cbor.IpldStore
 			return err
 		}
 
-		tokenAmount := verifreg9.DataCapToTokens(dcap)
+		tokenAmount := big.Mul(dcap, verifreg9.DataCapGranularity)
 		tokenSupply = big.Add(tokenSupply, tokenAmount)
 		if err = balancesMap.Put(abi.IdAddrKey(a), &tokenAmount); err != nil {
 			return xerrors.Errorf("failed to put new balancesMap entry: %w", err)

--- a/builtin/v9/migration/market.go
+++ b/builtin/v9/migration/market.go
@@ -1,0 +1,57 @@
+package migration
+
+import (
+	"context"
+
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/builtin"
+	market8 "github.com/filecoin-project/go-state-types/builtin/v8/market"
+	adt8 "github.com/filecoin-project/go-state-types/builtin/v8/util/adt"
+	market9 "github.com/filecoin-project/go-state-types/builtin/v9/market"
+	adt9 "github.com/filecoin-project/go-state-types/builtin/v9/util/adt"
+	verifreg9 "github.com/filecoin-project/go-state-types/builtin/v9/verifreg"
+	"github.com/ipfs/go-cid"
+	typegen "github.com/whyrusleeping/cbor-gen"
+	"golang.org/x/xerrors"
+)
+
+func migrateMarket(ctx context.Context, adtStore adt8.Store, dealsToAllocations map[abi.DealID]verifreg9.AllocationId, marketStateV8 market8.State, emptyMapCid cid.Cid) (cid.Cid, error) {
+	pendingDealAllocationIdsMap, err := adt9.AsMap(adtStore, emptyMapCid, builtin.DefaultHamtBitwidth)
+	if err != nil {
+		return cid.Undef, xerrors.Errorf("failed to load empty map: %w", err)
+	}
+
+	for dealID, allocationID := range dealsToAllocations {
+		cborAllocationID := typegen.CborInt(allocationID)
+		if err = pendingDealAllocationIdsMap.Put(abi.UIntKey(uint64(dealID)), &cborAllocationID); err != nil {
+			return cid.Undef, xerrors.Errorf("failed to populate pending deal allocations map: %w", err)
+		}
+	}
+
+	pendingDealAllocationIdsMapRoot, err := pendingDealAllocationIdsMap.Root()
+	if err != nil {
+		return cid.Undef, xerrors.Errorf("failed to flush pending deal allocations map: %w", err)
+	}
+
+	marketStateV9 := market9.State{
+		Proposals:                     marketStateV8.Proposals,
+		States:                        marketStateV8.States,
+		PendingProposals:              marketStateV8.PendingProposals,
+		EscrowTable:                   marketStateV8.EscrowTable,
+		LockedTable:                   marketStateV8.LockedTable,
+		NextID:                        marketStateV8.NextID,
+		DealOpsByEpoch:                marketStateV8.DealOpsByEpoch,
+		LastCron:                      marketStateV8.LastCron,
+		TotalClientLockedCollateral:   marketStateV8.TotalClientLockedCollateral,
+		TotalProviderLockedCollateral: marketStateV8.TotalProviderLockedCollateral,
+		TotalClientStorageFee:         marketStateV8.TotalClientStorageFee,
+		PendingDealAllocationIds:      pendingDealAllocationIdsMapRoot,
+	}
+
+	marketHead, err := adtStore.Put(ctx, &marketStateV9)
+	if err != nil {
+		return cid.Undef, xerrors.Errorf("failed to put market state: %w", err)
+	}
+
+	return marketHead, nil
+}

--- a/builtin/v9/migration/miner.go
+++ b/builtin/v9/migration/miner.go
@@ -3,13 +3,17 @@ package migration
 import (
 	"context"
 
+	adt9 "github.com/filecoin-project/go-state-types/builtin/v9/util/adt"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-amt-ipld/v4"
 	"golang.org/x/xerrors"
 
 	commp "github.com/filecoin-project/go-commp-utils/nonffi"
 	"github.com/filecoin-project/go-state-types/builtin"
 	"github.com/filecoin-project/go-state-types/builtin/v8/market"
 	miner8 "github.com/filecoin-project/go-state-types/builtin/v8/miner"
-	"github.com/filecoin-project/go-state-types/builtin/v8/util/adt"
+	adt8 "github.com/filecoin-project/go-state-types/builtin/v8/util/adt"
 	miner9 "github.com/filecoin-project/go-state-types/builtin/v9/miner"
 
 	"github.com/ipfs/go-cid"
@@ -18,9 +22,72 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 )
 
+// The minerMigrator performs the following migrations:
+// FIP-0029: Sets the Beneficary to the Owner, and sets empty values for BeneficiaryTerm and PendingBeneficiaryTerm
+// FIP-0034: For each SectorPreCommitOnChainInfo in PreCommitedSectors, calculates the unsealed CID (assuming there are deals)
+// FIP-0045: For each SectorOnChainInfo in Sectors, set SimpleQAPower = (DealWeight == 0 && VerifiedDealWeight == 0)
+// FIP-0045: For each Deadline in Deadlines: for each SectorOnChainInfo in SectorsSnapshot, set SimpleQAPower = (DealWeight == 0 && VerifiedDealWeight == 0)
+
 type minerMigrator struct {
-	proposals  *market.DealArray
-	OutCodeCID cid.Cid
+	emptyPrecommitOnChainInfosV9 cid.Cid
+	emptyDeadlineV8              cid.Cid
+	emptyDeadlinesV8             cid.Cid
+	emptyDeadlineV9              cid.Cid
+	emptyDeadlinesV9             cid.Cid
+	proposals                    *market.DealArray
+	OutCodeCID                   cid.Cid
+}
+
+func newMinerMigrator(ctx context.Context, store cbor.IpldStore, marketProposals *market.DealArray, outCode cid.Cid) (*minerMigrator, error) {
+	ctxStore := adt8.WrapStore(ctx, store)
+
+	emptyPrecommitMapCidV9, err := adt9.StoreEmptyMap(ctxStore, builtin.DefaultHamtBitwidth)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to construct empty precommit map v9: %w", err)
+	}
+
+	edv8, err := miner8.ConstructDeadline(ctxStore)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to construct empty deadline v8: %w", err)
+	}
+
+	edv8cid, err := store.Put(ctx, edv8)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to put empty deadline v8: %w", err)
+	}
+
+	edsv8 := miner8.ConstructDeadlines(edv8cid)
+	edsv8cid, err := store.Put(ctx, edsv8)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to construct empty deadlines v8: %w", err)
+	}
+
+	edv9, err := miner9.ConstructDeadline(ctxStore)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to construct empty deadline v9: %w", err)
+	}
+
+	edv9cid, err := store.Put(ctx, edv9)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to put empty deadline v9: %w", err)
+	}
+
+	edsv9 := miner9.ConstructDeadlines(edv9cid)
+	edsv9cid, err := store.Put(ctx, edsv9)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to construct empty deadlines v9: %w", err)
+
+	}
+
+	return &minerMigrator{
+		emptyPrecommitOnChainInfosV9: emptyPrecommitMapCidV9,
+		emptyDeadlineV8:              edv8cid,
+		emptyDeadlinesV8:             edsv8cid,
+		emptyDeadlineV9:              edv9cid,
+		emptyDeadlinesV9:             edsv9cid,
+		proposals:                    marketProposals,
+		OutCodeCID:                   outCode,
+	}, nil
 }
 
 func (m minerMigrator) migratedCodeCID() cid.Cid {
@@ -36,21 +103,90 @@ func (m minerMigrator) migrateState(ctx context.Context, store cbor.IpldStore, i
 	if err := store.Get(ctx, inState.Info, &inInfo); err != nil {
 		return nil, err
 	}
-	wrappedStore := adt.WrapStore(ctx, store)
+	wrappedStore := adt8.WrapStore(ctx, store)
 
-	oldPrecommitOnChainInfos, err := adt.AsMap(wrappedStore, inState.PreCommittedSectors, builtin.DefaultHamtBitwidth)
+	newPrecommits, err := m.migratePrecommits(ctx, wrappedStore, inState.PreCommittedSectors)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to load old precommit onchain infos for miner %s: %w", in.address, err)
+		return nil, xerrors.Errorf("failed to migrate precommits for miner: %s: %w", in.address, err)
 	}
 
-	emptyMap, err := adt.StoreEmptyMap(wrappedStore, builtin.DefaultHamtBitwidth)
+	newSectors, err := migrateSectorsWithCache(ctx, wrappedStore, in.cache, in.address, inState.Sectors)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to make empty map: %w", err)
+		return nil, xerrors.Errorf("failed to migrate sectors for miner: %s: %w", in.address, err)
 	}
 
-	newPrecommitOnChainInfos, err := adt.AsMap(wrappedStore, emptyMap, builtin.DefaultHamtBitwidth)
+	deadlinesOut, err := m.migrateDeadlines(ctx, wrappedStore, in.cache, inState.Deadlines)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to load empty map: %w", err)
+		return nil, xerrors.Errorf("failed to migrate deadlines: %w", err)
+	}
+
+	var newPendingWorkerKey *miner9.WorkerKeyChange
+	if inInfo.PendingWorkerKey != nil {
+		newPendingWorkerKey = &miner9.WorkerKeyChange{
+			NewWorker:   inInfo.PendingWorkerKey.NewWorker,
+			EffectiveAt: inInfo.PendingWorkerKey.EffectiveAt,
+		}
+	}
+
+	outInfo := miner9.MinerInfo{
+		Owner:       inInfo.Owner,
+		Worker:      inInfo.Worker,
+		Beneficiary: inInfo.Owner,
+		BeneficiaryTerm: miner9.BeneficiaryTerm{
+			Quota:      abi.NewTokenAmount(0),
+			UsedQuota:  abi.NewTokenAmount(0),
+			Expiration: 0,
+		},
+		PendingBeneficiaryTerm:     nil,
+		ControlAddresses:           inInfo.ControlAddresses,
+		PendingWorkerKey:           newPendingWorkerKey,
+		PeerId:                     inInfo.PeerId,
+		Multiaddrs:                 inInfo.Multiaddrs,
+		WindowPoStProofType:        inInfo.WindowPoStProofType,
+		SectorSize:                 inInfo.SectorSize,
+		WindowPoStPartitionSectors: inInfo.WindowPoStPartitionSectors,
+		ConsensusFaultElapsed:      inInfo.ConsensusFaultElapsed,
+		PendingOwnerAddress:        inInfo.PendingOwnerAddress,
+	}
+	newInfoCid, err := store.Put(ctx, &outInfo)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to flush new miner info: %w", err)
+	}
+
+	outState := miner9.State{
+		Info:                       newInfoCid,
+		PreCommitDeposits:          inState.PreCommitDeposits,
+		LockedFunds:                inState.LockedFunds,
+		VestingFunds:               inState.VestingFunds,
+		FeeDebt:                    inState.FeeDebt,
+		InitialPledge:              inState.InitialPledge,
+		PreCommittedSectors:        newPrecommits,
+		PreCommittedSectorsCleanUp: inState.PreCommittedSectorsCleanUp,
+		AllocatedSectors:           inState.AllocatedSectors,
+		Sectors:                    newSectors,
+		ProvingPeriodStart:         inState.ProvingPeriodStart,
+		CurrentDeadline:            inState.CurrentDeadline,
+		Deadlines:                  deadlinesOut,
+		EarlyTerminations:          inState.EarlyTerminations,
+		DeadlineCronActive:         inState.DeadlineCronActive,
+	}
+
+	newHead, err := store.Put(ctx, &outState)
+	return &actorMigrationResult{
+		newCodeCID: m.migratedCodeCID(),
+		newHead:    newHead,
+	}, err
+}
+
+func (m minerMigrator) migratePrecommits(ctx context.Context, wrappedStore adt8.Store, inRoot cid.Cid) (cid.Cid, error) {
+	oldPrecommitOnChainInfos, err := adt8.AsMap(wrappedStore, inRoot, builtin.DefaultHamtBitwidth)
+	if err != nil {
+		return cid.Undef, xerrors.Errorf("failed to load old precommit onchain infos: %w", err)
+	}
+
+	newPrecommitOnChainInfos, err := adt9.AsMap(wrappedStore, m.emptyPrecommitOnChainInfosV9, builtin.DefaultHamtBitwidth)
+	if err != nil {
+		return cid.Undef, xerrors.Errorf("failed to load empty map: %w", err)
 	}
 
 	var info miner8.SectorPreCommitOnChainInfo
@@ -100,68 +236,197 @@ func (m minerMigrator) migrateState(ctx context.Context, store cbor.IpldStore, i
 	})
 
 	if err != nil {
-		return nil, xerrors.Errorf("failed to iterate over precommitinfos: %w", err)
+		return cid.Undef, xerrors.Errorf("failed to iterate over precommitinfos: %w", err)
 	}
 
 	newPrecommits, err := newPrecommitOnChainInfos.Root()
 	if err != nil {
-		return nil, xerrors.Errorf("failed to flush new precommits: %w", err)
+		return cid.Undef, xerrors.Errorf("failed to flush new precommits: %w", err)
 	}
 
-	var newPendingWorkerKey *miner9.WorkerKeyChange
-	if inInfo.PendingWorkerKey != nil {
-		newPendingWorkerKey = &miner9.WorkerKeyChange{
-			NewWorker:   inInfo.PendingWorkerKey.NewWorker,
-			EffectiveAt: inInfo.PendingWorkerKey.EffectiveAt,
+	return newPrecommits, nil
+}
+
+func migrateSectorsWithCache(ctx context.Context, store adt8.Store, cache MigrationCache, minerAddr address.Address, inRoot cid.Cid) (cid.Cid, error) {
+	return cache.Load(SectorsAmtKey(inRoot), func() (cid.Cid, error) {
+		inArray, err := adt8.AsArray(store, inRoot, miner8.SectorsAmtBitwidth)
+		if err != nil {
+			return cid.Undef, xerrors.Errorf("failed to read sectors array: %w", err)
+		}
+
+		okIn, prevInRoot, err := cache.Read(MinerPrevSectorsInKey(minerAddr))
+		if err != nil {
+			return cid.Undef, xerrors.Errorf("failed to get previous inRoot from cache: %w", err)
+		}
+
+		okOut, prevOutRoot, err := cache.Read(MinerPrevSectorsOutKey(minerAddr))
+		if err != nil {
+			return cid.Undef, xerrors.Errorf("failed to get previous outRoot from cache: %w", err)
+		}
+
+		var outArray *adt9.Array
+		if okIn && okOut {
+			// we have previous work, but the AMT has changed -- diff them
+			diffs, err := amt.Diff(ctx, store, store, prevInRoot, inRoot, amt.UseTreeBitWidth(miner9.SectorsAmtBitwidth))
+			if err != nil {
+				return cid.Undef, xerrors.Errorf("failed to diff old and new Sector AMTs: %w", err)
+			}
+
+			inSectors, err := miner8.LoadSectors(store, inRoot)
+			if err != nil {
+				return cid.Undef, xerrors.Errorf("failed to load inSectors: %w", err)
+			}
+
+			prevOutSectors, err := miner9.LoadSectors(store, prevOutRoot)
+			if err != nil {
+				return cid.Undef, xerrors.Errorf("failed to load prevOutSectors: %w", err)
+			}
+
+			for _, change := range diffs {
+				switch change.Type {
+				case amt.Remove:
+					if err := prevOutSectors.Delete(change.Key); err != nil {
+						return cid.Undef, xerrors.Errorf("failed to delete sector from prevOutSectors: %w", err)
+					}
+				case amt.Add:
+					fallthrough
+				case amt.Modify:
+					sectorNo := abi.SectorNumber(change.Key)
+					info, found, err := inSectors.Get(sectorNo)
+					if err != nil {
+						return cid.Undef, xerrors.Errorf("failed to get sector %d in inSectors: %w", sectorNo, err)
+					}
+
+					if !found {
+						return cid.Undef, xerrors.Errorf("didn't find sector %d in inSectors", sectorNo)
+					}
+
+					if err := prevOutSectors.Set(change.Key, migrateSectorInfo(*info)); err != nil {
+						return cid.Undef, xerrors.Errorf("failed to set migrated sector %d in prevOutSectors", sectorNo)
+					}
+				}
+			}
+
+			outArray = prevOutSectors.Array
+		} else {
+			// first time we're doing this, do all the work
+			outArray, err = migrateSectorsFromScratch(ctx, store, inArray)
+			if err != nil {
+				return cid.Undef, xerrors.Errorf("failed to migrate sectors from scratch: %w", err)
+			}
+
+		}
+
+		outRoot, err := outArray.Root()
+		if err != nil {
+			return cid.Undef, xerrors.Errorf("error writing new sectors AMT: %w", err)
+		}
+
+		_ = cache.Write(MinerPrevSectorsInKey(minerAddr), inRoot)
+
+		_ = cache.Write(MinerPrevSectorsOutKey(minerAddr), outRoot)
+		return outRoot, nil
+	})
+}
+
+func migrateSectorsFromScratch(ctx context.Context, store adt8.Store, inArray *adt8.Array) (*adt9.Array, error) {
+	outArray, err := adt9.MakeEmptyArray(store, miner9.SectorsAmtBitwidth)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to construct new sectors array: %w", err)
+	}
+
+	var sectorInfo miner8.SectorOnChainInfo
+	if err = inArray.ForEach(&sectorInfo, func(k int64) error {
+		return outArray.Set(uint64(k), migrateSectorInfo(sectorInfo))
+	}); err != nil {
+		return nil, err
+	}
+
+	return outArray, err
+}
+
+// Need to introduce caching here too
+func (m minerMigrator) migrateDeadlines(ctx context.Context, store adt8.Store, cache MigrationCache, deadlines cid.Cid) (cid.Cid, error) {
+	if deadlines == m.emptyDeadlinesV8 {
+		return m.emptyDeadlinesV9, nil
+	}
+
+	var inDeadlines miner8.Deadlines
+	err := store.Get(store.Context(), deadlines, &inDeadlines)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	var outDeadlines miner9.Deadlines
+	for i, c := range inDeadlines.Due {
+		if c == m.emptyDeadlineV8 {
+			outDeadlines.Due[i] = m.emptyDeadlineV9
+		} else {
+			var inDeadline miner8.Deadline
+			if err = store.Get(ctx, c, &inDeadline); err != nil {
+				return cid.Undef, err
+			}
+
+			outSectorsSnapshotCid, err := cache.Load(SectorsAmtKey(inDeadline.SectorsSnapshot), func() (cid.Cid, error) {
+				inSectorsSnapshot, err := adt8.AsArray(store, inDeadline.SectorsSnapshot, miner8.SectorsAmtBitwidth)
+				if err != nil {
+					return cid.Undef, err
+				}
+
+				outSectorsSnapshot, err := migrateSectorsFromScratch(ctx, store, inSectorsSnapshot)
+				if err != nil {
+					return cid.Undef, xerrors.Errorf("failed to migrate sectors: %w", err)
+				}
+
+				return outSectorsSnapshot.Root()
+			})
+
+			if err != nil {
+				return cid.Undef, xerrors.Errorf("failed to migrate sectors snapshot: %w", err)
+			}
+
+			outDeadline := miner9.Deadline{
+				Partitions:                        inDeadline.Partitions,
+				ExpirationsEpochs:                 inDeadline.ExpirationsEpochs,
+				PartitionsPoSted:                  inDeadline.PartitionsPoSted,
+				EarlyTerminations:                 inDeadline.EarlyTerminations,
+				LiveSectors:                       inDeadline.LiveSectors,
+				TotalSectors:                      inDeadline.TotalSectors,
+				FaultyPower:                       miner9.PowerPair(inDeadline.FaultyPower),
+				OptimisticPoStSubmissions:         inDeadline.OptimisticPoStSubmissions,
+				SectorsSnapshot:                   outSectorsSnapshotCid,
+				PartitionsSnapshot:                inDeadline.PartitionsSnapshot,
+				OptimisticPoStSubmissionsSnapshot: inDeadline.OptimisticPoStSubmissionsSnapshot,
+			}
+
+			outDlCid, err := store.Put(ctx, &outDeadline)
+			if err != nil {
+				return cid.Undef, err
+			}
+
+			outDeadlines.Due[i] = outDlCid
 		}
 	}
 
-	outInfo := miner9.MinerInfo{
-		Owner:       inInfo.Owner,
-		Worker:      inInfo.Worker,
-		Beneficiary: inInfo.Owner,
-		BeneficiaryTerm: miner9.BeneficiaryTerm{
-			Quota:      abi.NewTokenAmount(0),
-			UsedQuota:  abi.NewTokenAmount(0),
-			Expiration: 0,
-		},
-		PendingBeneficiaryTerm:     nil,
-		ControlAddresses:           inInfo.ControlAddresses,
-		PendingWorkerKey:           newPendingWorkerKey,
-		PeerId:                     inInfo.PeerId,
-		Multiaddrs:                 inInfo.Multiaddrs,
-		WindowPoStProofType:        inInfo.WindowPoStProofType,
-		SectorSize:                 inInfo.SectorSize,
-		WindowPoStPartitionSectors: inInfo.WindowPoStPartitionSectors,
-		ConsensusFaultElapsed:      inInfo.ConsensusFaultElapsed,
-		PendingOwnerAddress:        inInfo.PendingOwnerAddress,
-	}
-	newInfoCid, err := store.Put(ctx, &outInfo)
-	if err != nil {
-		return nil, xerrors.Errorf("failed to flush new miner info: %w", err)
-	}
+	return store.Put(ctx, &outDeadlines)
+}
 
-	outState := miner9.State{
-		Info:                       newInfoCid,
-		PreCommitDeposits:          inState.PreCommitDeposits,
-		LockedFunds:                inState.LockedFunds,
-		VestingFunds:               inState.VestingFunds,
-		FeeDebt:                    inState.FeeDebt,
-		InitialPledge:              inState.InitialPledge,
-		PreCommittedSectors:        newPrecommits,
-		PreCommittedSectorsCleanUp: inState.PreCommittedSectorsCleanUp,
-		AllocatedSectors:           inState.AllocatedSectors,
-		Sectors:                    inState.Sectors,
-		ProvingPeriodStart:         inState.ProvingPeriodStart,
-		CurrentDeadline:            inState.CurrentDeadline,
-		Deadlines:                  inState.Deadlines,
-		EarlyTerminations:          inState.EarlyTerminations,
-		DeadlineCronActive:         inState.DeadlineCronActive,
+func migrateSectorInfo(sectorInfo miner8.SectorOnChainInfo) *miner9.SectorOnChainInfo {
+	return &miner9.SectorOnChainInfo{
+		SectorNumber:          sectorInfo.SectorNumber,
+		SealProof:             sectorInfo.SealProof,
+		SealedCID:             sectorInfo.SealedCID,
+		DealIDs:               sectorInfo.DealIDs,
+		Activation:            sectorInfo.Activation,
+		Expiration:            sectorInfo.Expiration,
+		DealWeight:            sectorInfo.DealWeight,
+		VerifiedDealWeight:    sectorInfo.VerifiedDealWeight,
+		InitialPledge:         sectorInfo.InitialPledge,
+		ExpectedDayReward:     sectorInfo.ExpectedDayReward,
+		ExpectedStoragePledge: sectorInfo.ExpectedStoragePledge,
+		ReplacedSectorAge:     sectorInfo.ReplacedSectorAge,
+		ReplacedDayReward:     sectorInfo.ReplacedDayReward,
+		SectorKeyCID:          sectorInfo.SectorKeyCID,
+		SimpleQAPower:         sectorInfo.DealWeight.IsZero() && sectorInfo.VerifiedDealWeight.IsZero(),
 	}
-
-	newHead, err := store.Put(ctx, &outState)
-	return &actorMigrationResult{
-		newCodeCID: m.migratedCodeCID(),
-		newHead:    newHead,
-	}, err
 }

--- a/builtin/v9/migration/system.go
+++ b/builtin/v9/migration/system.go
@@ -15,6 +15,10 @@ type systemActorMigrator struct {
 	ManifestData cid.Cid
 }
 
+func (m systemActorMigrator) migratedCodeCID() cid.Cid {
+	return m.OutCodeCID
+}
+
 func (m systemActorMigrator) migrateState(ctx context.Context, store cbor.IpldStore, in actorMigrationInput) (*actorMigrationResult, error) {
 	// The ManifestData itself is already in the blockstore
 	state := system.State{BuiltinActors: m.ManifestData}

--- a/builtin/v9/migration/test/migration_test.go
+++ b/builtin/v9/migration/test/migration_test.go
@@ -87,7 +87,7 @@ func TestMigration(t *testing.T) {
 	_ = oldStateTree.ForEach(func(addr address.Address, oldActor *migration.Actor) error {
 		newActor, ok, err := newStateTree.GetActor(addr)
 		require.NoError(t, err, "failed to get actor")
-		require.True(t, ok, "didn't find actor")
+		require.True(t, ok, "didn't find actor: %s", addr)
 		expectedCid, ok := cidsMap[oldActor.Code]
 		require.True(t, ok, "didn't find code in cidsmap")
 		require.Equal(t, expectedCid, newActor.Code)

--- a/builtin/v9/migration/test/util.go
+++ b/builtin/v9/migration/test/util.go
@@ -38,7 +38,7 @@ func makeTestManifest(t *testing.T, store adt.Store, prefix string) (cid.Cid, ci
 	builder := cid.V1Builder{Codec: cid.Raw, MhType: mh.IDENTITY}
 
 	newManifestData := manifest.ManifestData{}
-	for _, name := range []string{"system", "init", "cron", "account", "storagepower", "storageminer", "storagemarket", "paymentchannel", "multisig", "reward", "verifiedregistry"} {
+	for _, name := range manifest.GetBuiltinActorsKeys() {
 		codeCid, err := builder.Sum([]byte(fmt.Sprintf("%s%s", prefix, name)))
 		if err != nil {
 			t.Fatal(err)

--- a/builtin/v9/migration/test/util.go
+++ b/builtin/v9/migration/test/util.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/filecoin-project/go-state-types/actors"
+
 	"github.com/filecoin-project/go-state-types/rt"
 
 	block "github.com/ipfs/go-block-format"
@@ -38,7 +40,7 @@ func makeTestManifest(t *testing.T, store adt.Store, prefix string) (cid.Cid, ci
 	builder := cid.V1Builder{Codec: cid.Raw, MhType: mh.IDENTITY}
 
 	newManifestData := manifest.ManifestData{}
-	for _, name := range manifest.GetBuiltinActorsKeys() {
+	for _, name := range manifest.GetBuiltinActorsKeys(actors.Version9) {
 		codeCid, err := builder.Sum([]byte(fmt.Sprintf("%s%s", prefix, name)))
 		if err != nil {
 			t.Fatal(err)

--- a/builtin/v9/migration/top.go
+++ b/builtin/v9/migration/top.go
@@ -352,6 +352,8 @@ func MigrateStateTree(ctx context.Context, store cbor.IpldStore, newManifestCID 
 
 	// Create the Datacap actor
 
+	log.Log(rt.INFO, "Migrating datacap actor")
+
 	verifregActorV8, ok, err := actorsIn.GetActor(builtin.VerifiedRegistryActorAddr)
 	if err != nil {
 		return cid.Undef, xerrors.Errorf("failed to get verifreg actor: %w", err)
@@ -455,6 +457,8 @@ func MigrateStateTree(ctx context.Context, store cbor.IpldStore, newManifestCID 
 	}
 
 	// Migrate the Verified Registry Actor
+
+	log.Log(rt.INFO, "Migrating the verified registry actor")
 
 	initActorV9, ok, err := actorsOut.GetActor(builtin.InitActorAddr)
 	if err != nil {
@@ -600,6 +604,8 @@ func MigrateStateTree(ctx context.Context, store cbor.IpldStore, newManifestCID 
 
 	// Migrate the Market Actor
 
+	log.Log(rt.INFO, "Migrating the market actor")
+
 	pendingDealAllocationIdsMap, err := adt9.AsMap(adtStore, emptyMapCid, builtin.DefaultHamtBitwidth)
 	if err != nil {
 		return cid.Undef, xerrors.Errorf("failed to load empty map: %w", err)
@@ -649,6 +655,8 @@ func MigrateStateTree(ctx context.Context, store cbor.IpldStore, newManifestCID 
 	}); err != nil {
 		return cid.Undef, xerrors.Errorf("failed to set market actor: %w", err)
 	}
+
+	log.Log(rt.INFO, "Done all migrations, flushing state root")
 
 	return actorsOut.Flush()
 }

--- a/builtin/v9/migration/top.go
+++ b/builtin/v9/migration/top.go
@@ -6,6 +6,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	typegen "github.com/whyrusleeping/cbor-gen"
+
 	market9 "github.com/filecoin-project/go-state-types/builtin/v9/market"
 
 	init9 "github.com/filecoin-project/go-state-types/builtin/v9/init"
@@ -612,7 +614,8 @@ func MigrateStateTree(ctx context.Context, store cbor.IpldStore, newManifestCID 
 	}
 
 	for dealID, allocationID := range dealsToAllocations {
-		if err = pendingDealAllocationIdsMap.Put(abi.UIntKey(uint64(dealID)), allocationID); err != nil {
+		cborAllocationID := typegen.CborInt(allocationID)
+		if err = pendingDealAllocationIdsMap.Put(abi.UIntKey(uint64(dealID)), &cborAllocationID); err != nil {
 			return cid.Undef, xerrors.Errorf("failed to populate pending deal allocations map: %w", err)
 		}
 	}

--- a/builtin/v9/migration/verifreg.go
+++ b/builtin/v9/migration/verifreg.go
@@ -3,6 +3,8 @@ package migration
 import (
 	"context"
 
+	init8 "github.com/filecoin-project/go-state-types/builtin/v8/init"
+
 	verifreg8 "github.com/filecoin-project/go-state-types/builtin/v8/verifreg"
 
 	"github.com/filecoin-project/go-address"
@@ -10,7 +12,6 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 	market8 "github.com/filecoin-project/go-state-types/builtin/v8/market"
 	adt8 "github.com/filecoin-project/go-state-types/builtin/v8/util/adt"
-	init9 "github.com/filecoin-project/go-state-types/builtin/v9/init"
 	market9 "github.com/filecoin-project/go-state-types/builtin/v9/market"
 	adt9 "github.com/filecoin-project/go-state-types/builtin/v9/util/adt"
 	verifreg9 "github.com/filecoin-project/go-state-types/builtin/v9/verifreg"
@@ -18,7 +19,7 @@ import (
 	"golang.org/x/xerrors"
 )
 
-func migrateVerifreg(ctx context.Context, adtStore adt8.Store, priorEpoch abi.ChainEpoch, initStateV9 init9.State, marketStateV8 market8.State, verifregStateV8 verifreg8.State, emptyMapCid cid.Cid) (cid.Cid, map[abi.DealID]verifreg9.AllocationId, error) {
+func migrateVerifreg(ctx context.Context, adtStore adt8.Store, priorEpoch abi.ChainEpoch, initStateV9 init8.State, marketStateV8 market8.State, verifregStateV8 verifreg8.State, emptyMapCid cid.Cid) (cid.Cid, map[abi.DealID]verifreg9.AllocationId, error) {
 	pendingProposals, err := adt8.AsSet(adtStore, marketStateV8.PendingProposals, builtin.DefaultHamtBitwidth)
 	if err != nil {
 		return cid.Undef, nil, xerrors.Errorf("failed to load pending proposals: %w", err)

--- a/builtin/v9/migration/verifreg.go
+++ b/builtin/v9/migration/verifreg.go
@@ -32,6 +32,11 @@ func migrateVerifreg(ctx context.Context, adtStore adt8.Store, priorEpoch abi.Ch
 	pendingMap := make(map[abi.DealID]market8.DealProposal)
 	var proposal market8.DealProposal
 	if err = proposals.ForEach(&proposal, func(dealID int64) error {
+		// Nothing to do for unverified deals
+		if !proposal.VerifiedDeal {
+			return nil
+		}
+
 		pcid, err := proposal.Cid()
 		if err != nil {
 			return err

--- a/builtin/v9/migration/verifreg.go
+++ b/builtin/v9/migration/verifreg.go
@@ -89,16 +89,17 @@ func migrateVerifreg(ctx context.Context, adtStore adt8.Store, priorEpoch abi.Ch
 			if err != nil {
 				return cid.Undef, nil, xerrors.Errorf("failed to load empty map: %w", err)
 			}
+
+			allocationsMapMap[clientIDAddress] = clientAllocationMap
 		}
 
 		if err = clientAllocationMap.Put(nextAllocationID, &verifreg9.Allocation{
-			Client:   abi.ActorID(clientIDu64),
-			Provider: abi.ActorID(providerIDu64),
-			Data:     proposal.PieceCID,
-			Size:     proposal.PieceSize,
-			TermMin:  proposal.Duration(),
-			TermMax:  market9.DealMaxDuration,
-			// TODO: priorEpoch + 1???
+			Client:     abi.ActorID(clientIDu64),
+			Provider:   abi.ActorID(providerIDu64),
+			Data:       proposal.PieceCID,
+			Size:       proposal.PieceSize,
+			TermMin:    proposal.Duration(),
+			TermMax:    market9.DealMaxDuration,
 			Expiration: verifreg9.MaximumVerifiedAllocationExpiration + priorEpoch,
 		}); err != nil {
 			return cid.Undef, nil, xerrors.Errorf("failed to put new allocation obj: %w", err)

--- a/builtin/v9/migration/verifreg.go
+++ b/builtin/v9/migration/verifreg.go
@@ -1,0 +1,142 @@
+package migration
+
+import (
+	"context"
+
+	verifreg8 "github.com/filecoin-project/go-state-types/builtin/v8/verifreg"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/builtin"
+	market8 "github.com/filecoin-project/go-state-types/builtin/v8/market"
+	adt8 "github.com/filecoin-project/go-state-types/builtin/v8/util/adt"
+	init9 "github.com/filecoin-project/go-state-types/builtin/v9/init"
+	market9 "github.com/filecoin-project/go-state-types/builtin/v9/market"
+	adt9 "github.com/filecoin-project/go-state-types/builtin/v9/util/adt"
+	verifreg9 "github.com/filecoin-project/go-state-types/builtin/v9/verifreg"
+	"github.com/ipfs/go-cid"
+	"golang.org/x/xerrors"
+)
+
+func migrateVerifreg(ctx context.Context, adtStore adt8.Store, priorEpoch abi.ChainEpoch, initStateV9 init9.State, marketStateV8 market8.State, verifregStateV8 verifreg8.State, emptyMapCid cid.Cid) (cid.Cid, map[abi.DealID]verifreg9.AllocationId, error) {
+	pendingProposals, err := adt8.AsSet(adtStore, marketStateV8.PendingProposals, builtin.DefaultHamtBitwidth)
+	if err != nil {
+		return cid.Undef, nil, xerrors.Errorf("failed to load pending proposals: %w", err)
+	}
+
+	proposals, err := market8.AsDealProposalArray(adtStore, marketStateV8.Proposals)
+	if err != nil {
+		return cid.Undef, nil, xerrors.Errorf("failed to get proposals: %w", err)
+	}
+
+	pendingMap := make(map[abi.DealID]market8.DealProposal)
+	var proposal market8.DealProposal
+	if err = proposals.ForEach(&proposal, func(dealID int64) error {
+		pcid, err := proposal.Cid()
+		if err != nil {
+			return err
+		}
+
+		isPending, err := pendingProposals.Has(abi.CidKey(pcid))
+		if err != nil {
+			return xerrors.Errorf("failed to check pending: %w", err)
+		}
+
+		if isPending {
+			pendingMap[abi.DealID(dealID)] = proposal
+		}
+
+		return nil
+	}); err != nil {
+		return cid.Undef, nil, xerrors.Errorf("failed to iterate over proposals: %w", err)
+	}
+
+	nextAllocationID := verifreg9.AllocationId(1)
+	allocationsMapMap := make(map[address.Address]*adt9.Map)
+	dealsToAllocations := make(map[abi.DealID]verifreg9.AllocationId)
+	for dealID, proposal := range pendingMap {
+		clientIDAddress, ok, err := initStateV9.ResolveAddress(adtStore, proposal.Client)
+		if err != nil {
+			return cid.Undef, nil, xerrors.Errorf("failed to resolve client %s: %w", proposal.Client, err)
+		}
+
+		if !ok {
+			return cid.Undef, nil, xerrors.New("failed to find client in init actor map")
+		}
+
+		clientIDu64, err := address.IDFromAddress(clientIDAddress)
+		if err != nil {
+			return cid.Undef, nil, err
+		}
+
+		providerIDAddress, ok, err := initStateV9.ResolveAddress(adtStore, proposal.Provider)
+		if err != nil {
+			return cid.Undef, nil, xerrors.Errorf("failed to resolve provider %s: %w", proposal.Provider, err)
+		}
+
+		if !ok {
+			return cid.Undef, nil, xerrors.New("failed to find provider in init actor map")
+		}
+
+		providerIDu64, err := address.IDFromAddress(providerIDAddress)
+		if err != nil {
+			return cid.Undef, nil, err
+		}
+
+		clientAllocationMap, ok := allocationsMapMap[clientIDAddress]
+		if !ok {
+			clientAllocationMap, err = adt9.AsMap(adtStore, emptyMapCid, builtin.DefaultHamtBitwidth)
+			if err != nil {
+				return cid.Undef, nil, xerrors.Errorf("failed to load empty map: %w", err)
+			}
+		}
+
+		if err = clientAllocationMap.Put(nextAllocationID, &verifreg9.Allocation{
+			Client:   abi.ActorID(clientIDu64),
+			Provider: abi.ActorID(providerIDu64),
+			Data:     proposal.PieceCID,
+			Size:     proposal.PieceSize,
+			TermMin:  proposal.Duration(),
+			TermMax:  market9.DealMaxDuration,
+			// TODO: priorEpoch + 1???
+			Expiration: verifreg9.MaximumVerifiedAllocationExpiration + priorEpoch,
+		}); err != nil {
+			return cid.Undef, nil, xerrors.Errorf("failed to put new allocation obj: %w", err)
+		}
+
+		dealsToAllocations[dealID] = nextAllocationID
+		nextAllocationID++
+	}
+
+	allocationsMap, err := adt9.AsMap(adtStore, emptyMapCid, builtin.DefaultHamtBitwidth)
+	if err != nil {
+		return cid.Undef, nil, xerrors.Errorf("failed to load empty map: %w", err)
+	}
+
+	for clientID, clientAllocationsMap := range allocationsMapMap {
+		if err = allocationsMap.Put(abi.IdAddrKey(clientID), clientAllocationsMap); err != nil {
+			return cid.Undef, nil, xerrors.Errorf("failed to populate allocationsMap: %w", err)
+		}
+	}
+
+	allocationsMapRoot, err := allocationsMap.Root()
+	if err != nil {
+		return cid.Undef, nil, xerrors.Errorf("failed to flush allocations map: %w", err)
+	}
+
+	verifregStateV9 := verifreg9.State{
+		RootKey:                  verifregStateV8.RootKey,
+		Verifiers:                verifregStateV8.Verifiers,
+		RemoveDataCapProposalIDs: verifregStateV8.RemoveDataCapProposalIDs,
+		Allocations:              allocationsMapRoot,
+		NextAllocationId:         1,
+		Claims:                   emptyMapCid,
+	}
+
+	verifregHead, err := adtStore.Put(ctx, &verifregStateV9)
+	if err != nil {
+		return cid.Undef, nil, xerrors.Errorf("failed to put verifreg9 state: %w", err)
+	}
+
+	return verifregHead, dealsToAllocations, nil
+}

--- a/builtin/v9/util/adt/map.go
+++ b/builtin/v9/util/adt/map.go
@@ -3,6 +3,7 @@ package adt
 import (
 	"bytes"
 	"crypto/sha256"
+	"io"
 
 	hamt "github.com/filecoin-project/go-hamt-ipld/v3"
 	"github.com/filecoin-project/go-state-types/abi"
@@ -26,6 +27,16 @@ type Map struct {
 	lastCid cid.Cid
 	root    *hamt.Node
 	store   Store
+}
+
+func (m *Map) MarshalCBOR(w io.Writer) error {
+	rootCid, err := m.Root()
+	if err != nil {
+		return xerrors.Errorf("failed to flush map: %w", err)
+	}
+
+	scratch := make([]byte, 9)
+	return cbg.WriteCidBuf(scratch, w, rootCid)
 }
 
 // AsMap interprets a store as a HAMT-based map with root `r`.

--- a/builtin/v9/util/adt/map.go
+++ b/builtin/v9/util/adt/map.go
@@ -35,8 +35,8 @@ func (m *Map) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("failed to flush map: %w", err)
 	}
 
-	scratch := make([]byte, 9)
-	return cbg.WriteCidBuf(scratch, w, rootCid)
+	cborCid := cbg.CborCid(rootCid)
+	return cborCid.MarshalCBOR(w)
 }
 
 // AsMap interprets a store as a HAMT-based map with root `r`.

--- a/builtin/v9/util/adt/set.go
+++ b/builtin/v9/util/adt/set.go
@@ -1,0 +1,71 @@
+package adt
+
+import (
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/ipfs/go-cid"
+)
+
+// Set interprets a Map as a set, storing keys (with empty values) in a HAMT.
+type Set struct {
+	m *Map
+}
+
+// AsSet interprets a store as a HAMT-based set with root `r`.
+// The HAMT is interpreted with branching factor 2^bitwidth.
+func AsSet(s Store, r cid.Cid, bitwidth int) (*Set, error) {
+	m, err := AsMap(s, r, bitwidth)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Set{
+		m: m,
+	}, nil
+}
+
+// NewSet creates a new HAMT with root `r` and store `s`.
+// The HAMT has branching factor 2^bitwidth.
+func MakeEmptySet(s Store, bitwidth int) (*Set, error) {
+	m, err := MakeEmptyMap(s, bitwidth)
+	if err != nil {
+		return nil, err
+	}
+	return &Set{m}, nil
+}
+
+// Root return the root cid of HAMT.
+func (h *Set) Root() (cid.Cid, error) {
+	return h.m.Root()
+}
+
+// Put adds `k` to the set.
+func (h *Set) Put(k abi.Keyer) error {
+	return h.m.Put(k, nil)
+}
+
+// Has returns true iff `k` is in the set.
+func (h *Set) Has(k abi.Keyer) (bool, error) {
+	return h.m.Get(k, nil)
+}
+
+// Removes `k` from the set, if present.
+// Returns whether the key was previously present.
+func (h *Set) TryDelete(k abi.Keyer) (bool, error) {
+	return h.m.TryDelete(k)
+}
+
+// Removes `k` from the set, expecting it to be present.
+func (h *Set) Delete(k abi.Keyer) error {
+	return h.m.Delete(k)
+}
+
+// ForEach iterates over all values in the set, calling the callback for each value.
+// Returning error from the callback stops the iteration.
+func (h *Set) ForEach(cb func(k string) error) error {
+	return h.m.ForEach(nil, cb)
+}
+
+// Collects all the keys from the set into a slice of strings.
+func (h *Set) CollectKeys() (out []string, err error) {
+	return h.m.CollectKeys()
+}

--- a/builtin/v9/util/adt/set.go
+++ b/builtin/v9/util/adt/set.go
@@ -1,3 +1,5 @@
+// Ported from specs-actors: https://github.com/filecoin-project/specs-actors/blob/845089a6d2580e46055c24415a6c32ee688e5186/actors/util/adt/set.go#L8
+
 package adt
 
 import (

--- a/builtin/v9/verifreg/cbor_gen.go
+++ b/builtin/v9/verifreg/cbor_gen.go
@@ -7,6 +7,7 @@ import (
 	"io"
 
 	abi "github.com/filecoin-project/go-state-types/abi"
+	exitcode "github.com/filecoin-project/go-state-types/exitcode"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	xerrors "golang.org/x/xerrors"
 )
@@ -2021,12 +2022,16 @@ func (t *FailCode) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.Code (verifreg.ExitCode) (uint64)
-
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Code)); err != nil {
-		return err
+	// t.Code (exitcode.ExitCode) (int64)
+	if t.Code >= 0 {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Code)); err != nil {
+			return err
+		}
+	} else {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.Code-1)); err != nil {
+			return err
+		}
 	}
-
 	return nil
 }
 
@@ -2062,19 +2067,30 @@ func (t *FailCode) UnmarshalCBOR(r io.Reader) error {
 		t.Idx = uint64(extra)
 
 	}
-	// t.Code (verifreg.ExitCode) (uint64)
-
+	// t.Code (exitcode.ExitCode) (int64)
 	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+		var extraI int64
 		if err != nil {
 			return err
 		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative oveflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
 		}
-		t.Code = ExitCode(extra)
 
+		t.Code = exitcode.ExitCode(extraI)
 	}
 	return nil
 }

--- a/builtin/v9/verifreg/cbor_gen.go
+++ b/builtin/v9/verifreg/cbor_gen.go
@@ -50,7 +50,7 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("failed to write cid field t.Allocations: %w", err)
 	}
 
-	// t.NextAllocationId (uint64) (uint64)
+	// t.NextAllocationId (verifreg.AllocationId) (uint64)
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.NextAllocationId)); err != nil {
 		return err
@@ -128,7 +128,7 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		t.Allocations = c
 
 	}
-	// t.NextAllocationId (uint64) (uint64)
+	// t.NextAllocationId (verifreg.AllocationId) (uint64)
 
 	{
 
@@ -139,7 +139,7 @@ func (t *State) UnmarshalCBOR(r io.Reader) error {
 		if maj != cbg.MajUnsignedInt {
 			return fmt.Errorf("wrong type for uint64 field")
 		}
-		t.NextAllocationId = uint64(extra)
+		t.NextAllocationId = AllocationId(extra)
 
 	}
 	// t.Claims (cid.Cid) (struct)

--- a/builtin/v9/verifreg/verified_registry_state.go
+++ b/builtin/v9/verifreg/verified_registry_state.go
@@ -1,7 +1,6 @@
 package verifreg
 
 import (
-	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/builtin"
 	"github.com/filecoin-project/go-state-types/builtin/v9/util/adt"
 	cbg "github.com/whyrusleeping/cbor-gen"
@@ -17,14 +16,6 @@ import (
 type DataCap = abi.StoragePower
 
 var DataCapGranularity = builtin.TokenPrecision
-
-func DataCapToTokens(d DataCap) abi.TokenAmount {
-	return big.Mul(d, DataCapGranularity)
-}
-
-func TokensToDatacap(t abi.TokenAmount) DataCap {
-	return big.Div(t, DataCapGranularity)
-}
 
 const SignatureDomainSeparation_RemoveDataCap = "fil_removedatacap:"
 
@@ -51,7 +42,7 @@ type State struct {
 
 	// Next allocation identifier to use.
 	// The value 0 is reserved to mean "no allocation".
-	NextAllocationId uint64
+	NextAllocationId AllocationId
 
 	// Maps provider IDs to allocations claimed by that provider.
 	Claims cid.Cid // HAMT[ActorID]HAMT[ClaimID]Claim
@@ -160,7 +151,7 @@ func getInnerHamtCid(store adt.Store, key abi.Keyer, mapCid cid.Cid) (cid.Cid, e
 	return cid.Cid(innerHamtCid), nil
 }
 
-func (st *State) AllocationsMap(store adt.Store, clientIdAddr address.Address) (map[AllocationId]Allocation, error) {
+func (st *State) LoadAllocationsToMap(store adt.Store, clientIdAddr address.Address) (map[AllocationId]Allocation, error) {
 	if clientIdAddr.Protocol() != address.ID {
 		return nil, xerrors.Errorf("can only look up ID addresses")
 	}
@@ -192,7 +183,7 @@ func (st *State) AllocationsMap(store adt.Store, clientIdAddr address.Address) (
 	return goMap, nil
 }
 
-func (st *State) ClaimsMap(store adt.Store, providerIdAddr address.Address) (map[ClaimId]Claim, error) {
+func (st *State) LoadClaimsToMap(store adt.Store, providerIdAddr address.Address) (map[ClaimId]Claim, error) {
 	if providerIdAddr.Protocol() != address.ID {
 		return nil, xerrors.Errorf("can only look up ID addresses")
 	}

--- a/builtin/v9/verifreg/verified_registry_state.go
+++ b/builtin/v9/verifreg/verified_registry_state.go
@@ -1,6 +1,7 @@
 package verifreg
 
 import (
+	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/builtin"
 	"github.com/filecoin-project/go-state-types/builtin/v9/util/adt"
 
@@ -13,6 +14,16 @@ import (
 // DataCap is an integer number of bytes.
 // We can introduce policy changes and replace this in the future.
 type DataCap = abi.StoragePower
+
+var DataCapGranularity = builtin.TokenPrecision
+
+func DataCapToTokens(d DataCap) abi.TokenAmount {
+	return big.Mul(d, DataCapGranularity)
+}
+
+func TokensToDatacap(t abi.TokenAmount) DataCap {
+	return big.Div(t, DataCapGranularity)
+}
 
 const SignatureDomainSeparation_RemoveDataCap = "fil_removedatacap:"
 

--- a/builtin/v9/verifreg/verified_registry_state.go
+++ b/builtin/v9/verifreg/verified_registry_state.go
@@ -144,18 +144,82 @@ func (st *State) FindClaim(store adt.Store, providerIdAddr address.Address, clai
 	return &claim, true, nil
 }
 
-func getInnerHamtCid(store adt.Store, addr abi.Keyer, mapCid cid.Cid) (cid.Cid, error) {
+func getInnerHamtCid(store adt.Store, key abi.Keyer, mapCid cid.Cid) (cid.Cid, error) {
 	actorToHamtMap, err := adt.AsMap(store, mapCid, builtin.DefaultHamtBitwidth)
 	if err != nil {
 		return cid.Undef, xerrors.Errorf("couldn't get outer map: %x", err)
 	}
 
 	var innerHamtCid cbg.CborCid
-	if found, err := actorToHamtMap.Get(addr, &innerHamtCid); err != nil {
-		return cid.Undef, xerrors.Errorf("looking up key: %s: %w", addr, err)
+	if found, err := actorToHamtMap.Get(key, &innerHamtCid); err != nil {
+		return cid.Undef, xerrors.Errorf("looking up key: %s: %w", key, err)
 	} else if !found {
-		return cid.Undef, xerrors.Errorf("did not find key: %s", addr)
+		return cid.Undef, xerrors.Errorf("did not find key: %s", key)
 	}
 
 	return cid.Cid(innerHamtCid), nil
+}
+
+func (st *State) AllocationsMap(store adt.Store, clientIdAddr address.Address) (map[AllocationId]Allocation, error) {
+	if clientIdAddr.Protocol() != address.ID {
+		return nil, xerrors.Errorf("can only look up ID addresses")
+	}
+
+	innerHamtCid, err := getInnerHamtCid(store, abi.IdAddrKey(clientIdAddr), st.Allocations)
+	if err != nil {
+		return nil, err
+	}
+
+	adtMap, err := adt.AsMap(store, innerHamtCid, builtin.DefaultHamtBitwidth)
+	if err != nil {
+		return nil, xerrors.Errorf("couldn't get map: %x", err)
+	}
+
+	var goMap = make(map[AllocationId]Allocation)
+	var out Allocation
+	err = adtMap.ForEach(&out, func(key string) error {
+		uintKey, err := abi.ParseUIntKey(key)
+		if err != nil {
+			return xerrors.Errorf("couldn't parse key to uint: %x", err)
+		}
+		goMap[AllocationId(uintKey)] = out
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return goMap, nil
+}
+
+func (st *State) ClaimsMap(store adt.Store, providerIdAddr address.Address) (map[ClaimId]Claim, error) {
+	if providerIdAddr.Protocol() != address.ID {
+		return nil, xerrors.Errorf("can only look up ID addresses")
+	}
+
+	innerHamtCid, err := getInnerHamtCid(store, abi.IdAddrKey(providerIdAddr), st.Claims)
+	if err != nil {
+		return nil, err
+	}
+
+	adtMap, err := adt.AsMap(store, innerHamtCid, builtin.DefaultHamtBitwidth)
+	if err != nil {
+		return nil, xerrors.Errorf("couldn't get map: %x", err)
+	}
+
+	var goMap = make(map[ClaimId]Claim)
+	var out Claim
+	err = adtMap.ForEach(&out, func(key string) error {
+		uintKey, err := abi.ParseUIntKey(key)
+		if err != nil {
+			return xerrors.Errorf("couldn't parse key to uint: %w", err)
+		}
+		goMap[ClaimId(uintKey)] = out
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return goMap, nil
 }

--- a/builtin/v9/verifreg/verifreg_types.go
+++ b/builtin/v9/verifreg/verifreg_types.go
@@ -95,6 +95,10 @@ func (a AllocationId) Key() string {
 
 type ClaimId uint64
 
+func (a ClaimId) Key() string {
+	return string(varint.ToUvarint(uint64(a)))
+}
+
 type ClaimAllocationsParams struct {
 	Sectors      []SectorAllocationClaim
 	AllOrNothing bool

--- a/builtin/v9/verifreg/verifreg_types.go
+++ b/builtin/v9/verifreg/verifreg_types.go
@@ -1,10 +1,6 @@
 package verifreg
 
 import (
-	"io"
-
-	cbg "github.com/whyrusleeping/cbor-gen"
-
 	addr "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
@@ -92,11 +88,6 @@ type FailCode struct {
 type ExitCode uint64
 
 type AllocationId uint64
-
-func (a AllocationId) MarshalCBOR(w io.Writer) error {
-	scratch := make([]byte, 9)
-	return cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(a))
-}
 
 func (a AllocationId) Key() string {
 	return string(varint.ToUvarint(uint64(a)))

--- a/builtin/v9/verifreg/verifreg_types.go
+++ b/builtin/v9/verifreg/verifreg_types.go
@@ -1,11 +1,16 @@
 package verifreg
 
 import (
+	"io"
+
+	cbg "github.com/whyrusleeping/cbor-gen"
+
 	addr "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/crypto"
 	"github.com/ipfs/go-cid"
+	"github.com/multiformats/go-varint"
 )
 
 // RemoveDataCapProposal A verifier who wants to send/agree to a RemoveDataCapRequest should sign a RemoveDataCapProposal and send the signed proposal to the root key holder.
@@ -83,9 +88,20 @@ type FailCode struct {
 	Code ExitCode
 }
 
+// TODO: this shouldn't be here?
 type ExitCode uint64
 
 type AllocationId uint64
+
+func (a AllocationId) MarshalCBOR(w io.Writer) error {
+	scratch := make([]byte, 9)
+	return cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(a))
+}
+
+func (a AllocationId) Key() string {
+	return string(varint.ToUvarint(uint64(a)))
+}
+
 type ClaimId uint64
 
 type ClaimAllocationsParams struct {

--- a/builtin/v9/verifreg/verifreg_types.go
+++ b/builtin/v9/verifreg/verifreg_types.go
@@ -5,6 +5,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/crypto"
+	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/ipfs/go-cid"
 	"github.com/multiformats/go-varint"
 )
@@ -81,11 +82,8 @@ type BatchReturn struct {
 
 type FailCode struct {
 	Idx  uint64
-	Code ExitCode
+	Code exitcode.ExitCode
 }
-
-// TODO: this shouldn't be here?
-type ExitCode uint64
 
 type AllocationId uint64
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/ipfs/go-ipld-cbor v0.0.6
 	github.com/multiformats/go-multibase v0.0.3
 	github.com/multiformats/go-multihash v0.0.15
+	github.com/multiformats/go-varint v0.0.6
 	github.com/stretchr/testify v1.7.0
 	github.com/whyrusleeping/cbor-gen v0.0.0-20210118024343-169e9d70c0c2
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -12,6 +12,39 @@ import (
 	cbg "github.com/whyrusleeping/cbor-gen"
 )
 
+const (
+	AccountKey  = "account"
+	CronKey     = "cron"
+	DataCapKey  = "datacap"
+	InitKey     = "init"
+	MarketKey   = "storagemarket"
+	MinerKey    = "storageminer"
+	MultisigKey = "multisig"
+	PaychKey    = "paymentchannel"
+	PowerKey    = "storagepower"
+	RewardKey   = "reward"
+	SystemKey   = "system"
+	VerifregKey = "verifiedregistry"
+)
+
+func GetBuiltinActorsKeys() []string {
+	keys := []string{
+		AccountKey,
+		CronKey,
+		DataCapKey,
+		InitKey,
+		MarketKey,
+		MinerKey,
+		MultisigKey,
+		PaychKey,
+		PowerKey,
+		RewardKey,
+		SystemKey,
+		VerifregKey,
+	}
+	return keys
+}
+
 type Manifest struct {
 	Version uint64 // this is really u32, but cbor-gen can't deal with it
 	Data    cid.Cid

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 
+	actorstypes "github.com/filecoin-project/go-state-types/actors"
+
 	"github.com/filecoin-project/go-state-types/builtin/v8/util/adt"
 
 	"github.com/ipfs/go-cid"
@@ -27,11 +29,10 @@ const (
 	VerifregKey = "verifiedregistry"
 )
 
-func GetBuiltinActorsKeys() []string {
+func GetBuiltinActorsKeys(av actorstypes.Version) []string {
 	keys := []string{
 		AccountKey,
 		CronKey,
-		DataCapKey,
 		InitKey,
 		MarketKey,
 		MinerKey,
@@ -41,6 +42,9 @@ func GetBuiltinActorsKeys() []string {
 		RewardKey,
 		SystemKey,
 		VerifregKey,
+	}
+	if av >= 9 {
+		keys = append(keys, DataCapKey)
 	}
 	return keys
 }


### PR DESCRIPTION
Closes #69

**The sequence of steps is:**

- Step 0: Add the DataCap actor to the v8 state tree with a fake Head
- Step 1A: Migrate all actors except the StorageMarketActor and VerifiedRegistryActor as part of the "regular" migration workflow (more details on the migrations below), set the results in the output state tree
- Step 1B: In a separate, parallel goroutine migrate the VerifiedRegistryActor, and then the StorageMarketActor
- Block on 1A and 1B
- Step 2: Set the VerifiedRegistryActor and StorageMarketActor in the output state tree
- Step 3: Flush and return

**Miner Migration**

The minerMigrator performs the following migrations:
- FIP-0029: Sets the `Beneficary` to the `Owner`, and sets empty values for `BeneficiaryTerm and PendingBeneficiaryTerm`
- FIP-0034: For each `SectorPreCommitOnChainInfo` in `PreCommitedSectors`, calculates the unsealed CID (assuming there are deals)
- FIP-0045: For each SectorOnChainInfo in Sectors, set `SimpleQAPower = (DealWeight == 0 && VerifiedDealWeight == 0)`
- FIP-0045: For each Deadline in Deadlines: for each `SectorOnChainInfo` in `SectorsSnapshot`, set `SimpleQAPower = (DealWeight == 0 && VerifiedDealWeight == 0)`


The migration has the following layers of caching:

- at the `ActorHead` level -- if a matching `(address, Head)` tuple is found in the cache, use the cached value
- at the `SectorsAmt` level -- if a matching `Sectors` CID is found in the cache, use the cached value
  - This is used for migrating both the `Sectors` AMT, as well as the `SectorsSnapshot` AMTs in each deadline
- at the "previous SectorsAmt" level -- if we have the previous input and output of migrating this particular miner's SectorsAmt before, load them, and transform previous output to current output based on the diff between previous input and current input

Further caching is possible at the following levels;
- at the `PreCommits` level -- if a matching `PreCommittedSectors` CID is found in the cache, use the cached value
- at the individual `PreCommit` level -- if a matching `SectorPreCommitOnChainInfo` CID is found in the cache, use the cached value

**DataCap "migration"**

The `DataCap` State is set based on the Verified Registry's `VerifiedClients` map. For each client:
- its balance is converted to tokens that are added to the `TokenState`
- an entry is created in the TokenState's `allowances` map, with infinite allowance and the Market actor as operator

**VerifiedRegistry & Market migration**

As in #69 