### PR TITLE
Add accessors in verifreg actor

### DIFF
--- a/builtin/shared.go
+++ b/builtin/shared.go
@@ -10,6 +10,8 @@ import (
 // This value has been empirically chosen, but the optimal value for maps with different mutation profiles may differ.
 const DefaultHamtBitwidth = 5
 
+const DefaultTokenActorBitwidth = 3
+
 type BigFrac struct {
 	Numerator   big.Int
 	Denominator big.Int


### PR DESCRIPTION
Adds accessor functions that return a map of all claims or all allocations for a given actor.