### PR TITLE
Tweak Verifreg migration params

### DIFF
--- a/builtin/v9/migration/test/migration_test.go
+++ b/builtin/v9/migration/test/migration_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestMigration(t *testing.T) {
 	ctx := context.Background()
-	bs := cbor.NewMemCborStore()
+	bs := cbor.NewCborStore(NewSyncBlockStoreInMemory())
 	adtStore := adt.WrapStore(ctx, bs)
 
 	startRoot := makeInputTree(ctx, t, adtStore)

--- a/builtin/v9/migration/test/miner_test.go
+++ b/builtin/v9/migration/test/miner_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestMinerMigration(t *testing.T) {
 	ctx := context.Background()
-	bs := cbor.NewMemCborStore()
+	bs := cbor.NewCborStore(NewSyncBlockStoreInMemory())
 	adtStore := adt.WrapStore(ctx, bs)
 
 	startRoot := makeInputTree(ctx, t, adtStore)
@@ -317,7 +317,7 @@ func TestMinerMigration(t *testing.T) {
 
 func TestFip0029MinerMigration(t *testing.T) {
 	ctx := context.Background()
-	bs := cbor.NewMemCborStore()
+	bs := cbor.NewCborStore(NewSyncBlockStoreInMemory())
 	adtStore := adt.WrapStore(ctx, bs)
 
 	startRoot := makeInputTree(ctx, t, adtStore)

--- a/builtin/v9/migration/verifreg.go
+++ b/builtin/v9/migration/verifreg.go
@@ -76,6 +76,12 @@ func migrateVerifreg(ctx context.Context, adtStore adt8.Store, priorEpoch abi.Ch
 			allocationsMapMap[clientIDAddress] = clientAllocationMap
 		}
 
+		termMin := proposal.Duration()
+		termMax := termMin + market9.MarketDefaultAllocationTermBuffer
+		if termMax > verifreg9.MaximumVerifiedAllocationTerm {
+			termMax = verifreg9.MaximumVerifiedAllocationTerm
+		}
+
 		expiration := verifreg9.MaximumVerifiedAllocationExpiration + priorEpoch
 		if expiration > proposal.StartEpoch {
 			expiration = proposal.StartEpoch
@@ -86,8 +92,8 @@ func migrateVerifreg(ctx context.Context, adtStore adt8.Store, priorEpoch abi.Ch
 			Provider:   abi.ActorID(providerIDu64),
 			Data:       proposal.PieceCID,
 			Size:       proposal.PieceSize,
-			TermMin:    proposal.Duration(),
-			TermMax:    market9.DealMaxDuration + market9.MarketDefaultAllocationTermBuffer,
+			TermMin:    termMin,
+			TermMax:    termMax,
 			Expiration: expiration,
 		}); err != nil {
 			return xerrors.Errorf("failed to put new allocation obj: %w", err)


### PR DESCRIPTION
Outstanding issue from [here](https://github.com/filecoin-project/go-state-types/pull/85#discussion_r989550336). This now matches market actor code: https://github.com/filecoin-project/builtin-actors/blob/5934421954d63e7ec84b4ba6eaac1e30811e9a05/actors/market/src/lib.rs#L1141-L1147.