### PR TITLE
fix: make datacap methods a map instead of array

### DIFF
--- a/builtin/v9/datacap/methods.go
+++ b/builtin/v9/datacap/methods.go
@@ -5,7 +5,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 )
 
-var Methods = []interface{}{
+var Methods = map[uint64]interface{}{
 	1: *new(func(interface{}, *address.Address) *abi.EmptyValue), // Constructor
 	2: *new(func(interface{}, *MintParams) *MintReturn),          // Mint
 	3: *new(func(interface{}, *DestroyParams) *BurnReturn),       // Destroy


### PR DESCRIPTION
I missed this actor when we changed the methods files in a previous PR