### PR TITLE
fix: simpleQAP migration

### DIFF
--- a/builtin/v9/migration/miner.go
+++ b/builtin/v9/migration/miner.go
@@ -438,6 +438,6 @@ func migrateSectorInfo(sectorInfo miner8.SectorOnChainInfo) *miner9.SectorOnChai
 		ReplacedSectorAge:     sectorInfo.ReplacedSectorAge,
 		ReplacedDayReward:     sectorInfo.ReplacedDayReward,
 		SectorKeyCID:          sectorInfo.SectorKeyCID,
-		SimpleQAPower:         sectorInfo.DealWeight.IsZero() && sectorInfo.VerifiedDealWeight.IsZero(),
+		SimpleQAPower:         !sectorInfo.VerifiedDealWeight.IsZero(),
 	}
 }

--- a/builtin/v9/migration/miner.go
+++ b/builtin/v9/migration/miner.go
@@ -27,8 +27,8 @@ import (
 // The minerMigrator performs the following migrations:
 // FIP-0029: Sets the Beneficary to the Owner, and sets empty values for BeneficiaryTerm and PendingBeneficiaryTerm
 // FIP-0034: For each SectorPreCommitOnChainInfo in PreCommitedSectors, calculates the unsealed CID (assuming there are deals)
-// FIP-0045: For each SectorOnChainInfo in Sectors, set SimpleQAPower = (DealWeight == 0 && VerifiedDealWeight == 0)
-// FIP-0045: For each Deadline in Deadlines: for each SectorOnChainInfo in SectorsSnapshot, set SimpleQAPower = (DealWeight == 0 && VerifiedDealWeight == 0)
+// FIP-0045: For each SectorOnChainInfo in Sectors, set SimpleQAPower = (VerifiedDealWeight != 0)
+// FIP-0045: For each Deadline in Deadlines: for each SectorOnChainInfo in SectorsSnapshot, set SimpleQAPower = (VerifiedDealWeight != 0)
 
 type minerMigrator struct {
 	emptyPrecommitOnChainInfosV9 cid.Cid


### PR DESCRIPTION
for sectors that have verified deals prior to nv17 - fip0045, they will keep the "less simple QAP" mechsim, meaning QAP will be spread according to space-time upon extension 