### PR TITLE
fix: verifreg migration: set TermMax to DealMaxDuration

### DIFF
--- a/builtin/v9/migration/verifreg.go
+++ b/builtin/v9/migration/verifreg.go
@@ -76,12 +76,6 @@ func migrateVerifreg(ctx context.Context, adtStore adt8.Store, priorEpoch abi.Ch
 			allocationsMapMap[clientIDAddress] = clientAllocationMap
 		}
 
-		termMin := proposal.Duration()
-		termMax := termMin + market9.MarketDefaultAllocationTermBuffer
-		if termMax > verifreg9.MaximumVerifiedAllocationTerm {
-			termMax = verifreg9.MaximumVerifiedAllocationTerm
-		}
-
 		expiration := verifreg9.MaximumVerifiedAllocationExpiration + priorEpoch
 		if expiration > proposal.StartEpoch {
 			expiration = proposal.StartEpoch
@@ -92,8 +86,8 @@ func migrateVerifreg(ctx context.Context, adtStore adt8.Store, priorEpoch abi.Ch
 			Provider:   abi.ActorID(providerIDu64),
 			Data:       proposal.PieceCID,
 			Size:       proposal.PieceSize,
-			TermMin:    termMin,
-			TermMax:    termMax,
+			TermMin:    proposal.Duration(),
+			TermMax:    market9.DealMaxDuration,
 			Expiration: expiration,
 		}); err != nil {
 			return xerrors.Errorf("failed to put new allocation obj: %w", err)


### PR DESCRIPTION
This un-un-takes back the discussion [here](https://github.com/filecoin-project/go-state-types/pull/85#discussion_r989515121), and undoes the change in #91. 

If we land this, we should close https://github.com/filecoin-project/FIPs/pull/485, since we would be agreeing that the FIP is correct after all.