### PR TITLE
add the Ethereum Address Manager as a singleton.

### DIFF
--- a/builtin/singletons.go
+++ b/builtin/singletons.go
@@ -16,6 +16,10 @@ var (
 	VerifiedRegistryActorAddr = mustMakeAddress(6)
 	// Distinguished AccountActor that is the destination of all burnt funds.
 	BurntFundsActorAddr = mustMakeAddress(99)
+
+	// EthereumAddressManagerActorID is the actor ID of the Ethereum Address Manager singleton.
+	EthereumAddressManagerActorID   = uint64(10)
+	EthereumAddressManagerActorAddr = mustMakeAddress(EthereumAddressManagerActorID)
 )
 
 const FirstNonSingletonActorId = 100


### PR DESCRIPTION
Need the actor ID separately because we don't want to parse it from the address every time we construct a delegated address.