### PR TITLE
Add verifreg balance to datacap

### DIFF
--- a/builtin/v9/migration/datacap.go
+++ b/builtin/v9/migration/datacap.go
@@ -20,9 +20,10 @@ import (
 )
 
 type datacapMigrator struct {
-	emptyMapCid     cid.Cid
-	verifregStateV8 verifreg8.State
-	OutCodeCID      cid.Cid
+	emptyMapCid             cid.Cid
+	verifregStateV8         verifreg8.State
+	OutCodeCID              cid.Cid
+	pendingVerifiedDealSize uint64
 }
 
 func (d *datacapMigrator) migratedCodeCID() cid.Cid {
@@ -74,6 +75,9 @@ func (d *datacapMigrator) migrateState(ctx context.Context, store cbor.IpldStore
 	}); err != nil {
 		return nil, xerrors.Errorf("failed to loop over verified clients: %w", err)
 	}
+	verifregBalance := big.Mul(big.NewIntUnsigned(d.pendingVerifiedDealSize), verifreg9.DataCapGranularity)
+	tokenSupply = big.Add(tokenSupply, verifregBalance)
+	balancesMap.Put(abi.IdAddrKey(builtin.VerifiedRegistryActorAddr), &verifregBalance)
 
 	balancesMapRoot, err := balancesMap.Root()
 	if err != nil {

--- a/builtin/v9/migration/datacap.go
+++ b/builtin/v9/migration/datacap.go
@@ -77,7 +77,9 @@ func (d *datacapMigrator) migrateState(ctx context.Context, store cbor.IpldStore
 	}
 	verifregBalance := big.Mul(big.NewIntUnsigned(d.pendingVerifiedDealSize), verifreg9.DataCapGranularity)
 	tokenSupply = big.Add(tokenSupply, verifregBalance)
-	balancesMap.Put(abi.IdAddrKey(builtin.VerifiedRegistryActorAddr), &verifregBalance)
+	if err = balancesMap.Put(abi.IdAddrKey(builtin.VerifiedRegistryActorAddr), &verifregBalance); err != nil {
+		return nil, xerrors.Errorf("failed to put verifreg balance in balancesMap: %w", err)
+	}
 
 	balancesMapRoot, err := balancesMap.Root()
 	if err != nil {

--- a/builtin/v9/migration/util.go
+++ b/builtin/v9/migration/util.go
@@ -1,8 +1,13 @@
 package migration
 
 import (
+	"context"
 	"sync"
 
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/builtin"
+	market8 "github.com/filecoin-project/go-state-types/builtin/v8/market"
+	adt8 "github.com/filecoin-project/go-state-types/builtin/v8/util/adt"
 	"github.com/ipfs/go-cid"
 	"golang.org/x/xerrors"
 )
@@ -60,4 +65,46 @@ func (m *MemMigrationCache) Update(other *MemMigrationCache) {
 		m.MigrationMap.Store(key, value)
 		return true
 	})
+}
+
+func getPendingVerifiedDealsAndTotalSize(ctx context.Context, adtStore adt8.Store, marketStateV8 market8.State) ([]abi.DealID, uint64, error) {
+	pendingProposals, err := adt8.AsSet(adtStore, marketStateV8.PendingProposals, builtin.DefaultHamtBitwidth)
+	if err != nil {
+		return nil, 0, xerrors.Errorf("failed to load pending proposals: %w", err)
+	}
+
+	proposals, err := market8.AsDealProposalArray(adtStore, marketStateV8.Proposals)
+	if err != nil {
+		return nil, 0, xerrors.Errorf("failed to get proposals: %w", err)
+	}
+	var pendingVerifiedDeals []abi.DealID
+	pendingSize := uint64(0)
+	var proposal market8.DealProposal
+	if err = proposals.ForEach(&proposal, func(dealID int64) error {
+		// Nothing to do for unverified deals
+		if !proposal.VerifiedDeal {
+			return nil
+		}
+
+		pcid, err := proposal.Cid()
+		if err != nil {
+			return err
+		}
+
+		isPending, err := pendingProposals.Has(abi.CidKey(pcid))
+		if err != nil {
+			return xerrors.Errorf("failed to check pending: %w", err)
+		}
+
+		// Nothing to do for not-pending deals
+		if !isPending {
+			return nil
+		}
+		pendingVerifiedDeals = append(pendingVerifiedDeals, abi.DealID(dealID))
+		pendingSize += uint64(proposal.PieceSize)
+		return nil
+	}); err != nil {
+		return nil, 0, xerrors.Errorf("failed to iterate over proposals: %w", err)
+	}
+	return pendingVerifiedDeals, pendingSize, nil
 }


### PR DESCRIPTION
This refactors full proposal traversal to a single preliminary call that collects deal IDs of verified pending deals for verifreg migration and their total size for datacap migration