### PR TITLE
Invariant checks: don't expand big allocatedSectors bitfields

### DIFF
--- a/builtin/v8/miner/invariants.go
+++ b/builtin/v8/miner/invariants.go
@@ -6,6 +6,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/builtin/v8/util"
+	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-state-types/builtin"
 	"github.com/filecoin-project/go-state-types/builtin/v8/util/adt"
@@ -55,14 +56,15 @@ func CheckStateInvariants(st *State, store adt.Store, balance abi.TokenAmount) (
 	if err := store.Get(store.Context(), st.AllocatedSectors, &allocatedSectors); err != nil {
 		acc.Addf("error loading allocated sector bitfield: %v", err)
 	} else {
-		allocatedSectorsMap, err = allocatedSectors.AllMap(abi.MaxSectorNumber)
-		if err != nil {
+		allocatedSectorsMap, err = allocatedSectors.AllMap(1 << 30)
+		// if it's too big to expand, we'll fall back on the bitfield directly
+		if err != nil && !xerrors.Is(err, bitfield.ErrBitFieldTooMany) {
 			acc.Addf("error expanding allocated sector bitfield: %v", err)
 			allocatedSectorsMap = nil
 		}
 	}
 
-	CheckPreCommits(st, store, allocatedSectorsMap, acc)
+	CheckPreCommits(st, store, allocatedSectorsMap, allocatedSectors, acc)
 
 	minerSummary.Deals = map[abi.DealID]DealSummary{}
 	var allSectors map[abi.SectorNumber]*SectorOnChainInfo
@@ -74,7 +76,18 @@ func CheckStateInvariants(st *State, store adt.Store, balance abi.TokenAmount) (
 		err = sectorsArr.ForEach(&sector, func(sno int64) error {
 			cpy := sector
 			allSectors[abi.SectorNumber(sno)] = &cpy
-			acc.Require(allocatedSectorsMap == nil || allocatedSectorsMap[uint64(sno)],
+			allocated := false
+			if allocatedSectorsMap != nil {
+				allocated = allocatedSectorsMap[uint64(sno)]
+			} else {
+				allocated, err = allocatedSectors.IsSet(uint64(sno))
+				if err != nil {
+					acc.Addf("error checking allocated sectors: %v", err)
+					return nil
+				}
+			}
+
+			acc.Require(allocated,
 				"on chain sector's sector number has not been allocated %d", sno)
 
 			for _, dealID := range sector.DealIDs {
@@ -754,7 +767,7 @@ func CheckMinerBalances(st *State, store adt.Store, balance abi.TokenAmount, acc
 	}
 }
 
-func CheckPreCommits(st *State, store adt.Store, allocatedSectors map[uint64]bool, acc *builtin.MessageAccumulator) {
+func CheckPreCommits(st *State, store adt.Store, allocatedSectorsMap map[uint64]bool, allocatedSectorsBf bitfield.BitField, acc *builtin.MessageAccumulator) {
 	quant := st.QuantSpecEveryDeadline()
 
 	// invert pre-commit clean up queue into a lookup by sector number
@@ -788,7 +801,18 @@ func CheckPreCommits(st *State, store adt.Store, allocatedSectors map[uint64]boo
 				return nil
 			}
 
-			acc.Require(allocatedSectors[secNum], "pre-committed sector number has not been allocated %d", secNum)
+			allocated := false
+			if allocatedSectorsMap != nil {
+				allocated = allocatedSectorsMap[secNum]
+			} else {
+				allocated, err = allocatedSectorsBf.IsSet(secNum)
+				if err != nil {
+					acc.Addf("error checking allocated sectors: %v", err)
+					return nil
+				}
+			}
+
+			acc.Require(allocated, "pre-committed sector number has not been allocated %d", secNum)
 
 			_, found := cleanUpEpochs[secNum]
 			acc.Require(found, "no clean up epoch for pre-commit at %d", precommit.PreCommitEpoch)

--- a/builtin/v9/check.go
+++ b/builtin/v9/check.go
@@ -274,6 +274,8 @@ func CheckVerifregAgainstDatacap(acc *builtin.MessageAccumulator, verifregSummar
 	for _, allocation := range verifregSummary.Allocations {
 		pendingAllocationsTotal = big.Add(pendingAllocationsTotal, big.NewIntUnsigned(uint64(allocation.Size)))
 	}
+
+	pendingAllocationsTotal = big.Mul(pendingAllocationsTotal, verifreg.DataCapGranularity)
 	verifregId, err := address.IDFromAddress(builtin.VerifiedRegistryActorAddr)
 	acc.RequireNoError(err, "could not get verifreg ID from address")
 	verifregBalance, found := datacapSummary.Balances[abi.ActorID(verifregId)]

--- a/builtin/v9/migration/market.go
+++ b/builtin/v9/migration/market.go
@@ -9,6 +9,7 @@ import (
 	adt8 "github.com/filecoin-project/go-state-types/builtin/v8/util/adt"
 	market9 "github.com/filecoin-project/go-state-types/builtin/v9/market"
 	adt9 "github.com/filecoin-project/go-state-types/builtin/v9/util/adt"
+	"github.com/filecoin-project/go-state-types/builtin/v9/verifreg"
 	"github.com/ipfs/go-cid"
 	typegen "github.com/whyrusleeping/cbor-gen"
 	"golang.org/x/xerrors"
@@ -32,9 +33,42 @@ func migrateMarket(ctx context.Context, adtStore adt8.Store, dealAllocationTuple
 		return cid.Undef, xerrors.Errorf("failed to flush pending deal allocations map: %w", err)
 	}
 
+	dealStates8, err := adt9.AsArray(adtStore, marketStateV8.States, market8.StatesAmtBitwidth)
+	if err != nil {
+		return cid.Undef, xerrors.Errorf("failed to load v8 states array: %w", err)
+	}
+
+	emptyStatesArrayCid, err := adt9.StoreEmptyArray(adtStore, market9.StatesAmtBitwidth)
+	if err != nil {
+		return cid.Undef, xerrors.Errorf("failed to create empty states array: %w", err)
+	}
+
+	dealStates9, err := adt9.AsArray(adtStore, emptyStatesArrayCid, market9.StatesAmtBitwidth)
+	if err != nil {
+		return cid.Undef, xerrors.Errorf("failed to load v9 states array: %w", err)
+	}
+
+	var dealState8 market8.DealState
+	err = dealStates8.ForEach(&dealState8, func(i int64) error {
+		return dealStates9.Set(uint64(i), &market9.DealState{
+			SectorStartEpoch: dealState8.SectorStartEpoch,
+			LastUpdatedEpoch: dealState8.LastUpdatedEpoch,
+			SlashEpoch:       dealState8.SlashEpoch,
+			VerifiedClaim:    verifreg.NoAllocationID,
+		})
+	})
+	if err != nil {
+		return cid.Undef, xerrors.Errorf("failed to iterate over v8 states: %w", err)
+	}
+
+	dealStates9Root, err := dealStates9.Root()
+	if err != nil {
+		return cid.Undef, xerrors.Errorf("failed to flush dealStates 9: %w", err)
+	}
+
 	marketStateV9 := market9.State{
 		Proposals:                     marketStateV8.Proposals,
-		States:                        marketStateV8.States,
+		States:                        dealStates9Root,
 		PendingProposals:              marketStateV8.PendingProposals,
 		EscrowTable:                   marketStateV8.EscrowTable,
 		LockedTable:                   marketStateV8.LockedTable,


### PR DESCRIPTION
If this bitfield is too big, don't expand it, and look up values in the bitfield directly -- slower, but acceptable.