### PR TITLE
fix: Add allowance method to Datacap Actor

### DIFF
--- a/builtin/methods.go
+++ b/builtin/methods.go
@@ -144,4 +144,5 @@ var MethodsDatacap = struct {
 	RevokeAllowance   abi.MethodNum
 	Burn              abi.MethodNum
 	BurnFrom          abi.MethodNum
-}{MethodConstructor, 2, 3, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
+	Allowance         abi.MethodNum
+}{MethodConstructor, 2, 3, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21}

--- a/builtin/v9/datacap/methods.go
+++ b/builtin/v9/datacap/methods.go
@@ -23,4 +23,5 @@ var Methods = map[uint64]builtin.MethodMeta{
 	18: {"RevokeAllowance", *new(func(*RevokeAllowanceParams) *abi.TokenAmount)},     // RevokeAllowance
 	19: {"Burn", *new(func(*BurnParams) *BurnReturn)},                                // Burn
 	20: {"BurnFrom", *new(func(*BurnFromParams) *BurnFromReturn)},                    // BurnFrom
+	21: {"Allowance", *new(func(*GetAllowanceParams) *abi.TokenAmount)},              // Allowance
 }


### PR DESCRIPTION
Adds a missing method from the datacap actor. Corresponding `builtin-actors` PR [here](https://github.com/filecoin-project/builtin-actors/pull/795)