### PR TITLE
feat: add a method for validating an address for a network version

### DIFF
--- a/abi/address.go
+++ b/abi/address.go
@@ -1,0 +1,26 @@
+package abi
+
+import (
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/network"
+)
+
+// AddressValidForNetworkVersion returns true if the address is supported by the given network
+// version.
+//
+// NOTE: It will _also_ return true if the address is "empty", because all versions support empty
+// addresses in some places. I.e., it's not a version specific check.
+func AddressValidForNetworkVersion(addr address.Address, nv network.Version) bool {
+	// We define "undefined" addresses as "supported". The user should check for those
+	// separately.
+	if addr == address.Undef {
+		return true
+	}
+
+	switch addr.Protocol() {
+	case address.ID, address.SECP256K1, address.Actor, address.BLS:
+		return true
+	default:
+		return false
+	}
+}

--- a/abi/address_test.go
+++ b/abi/address_test.go
@@ -1,0 +1,19 @@
+package abi
+
+import (
+	"testing"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/network"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddressValidForNetworkVersion(t *testing.T) {
+	id, _ := address.NewIDAddress(1)
+	bls, _ := address.NewBLSAddress(make([]byte, address.BlsPublicKeyBytes))
+	secp, _ := address.NewSecp256k1Address(make([]byte, address.PayloadHashLength))
+	actor, _ := address.NewActorAddress(make([]byte, address.PayloadHashLength))
+	for _, addr := range []address.Address{id, bls, secp, actor} {
+		require.True(t, AddressValidForNetworkVersion(addr, network.Version17))
+	}
+}


### PR DESCRIPTION
Currently, all addresses are valid (up to nv17). When we land the nv18 patch, we'll allow "delegated" addresses in nv18 only.