### PR TITLE
fix: Universal Receiver method for account and verifreg take abi.EmptyValue

### DIFF
--- a/abi/cbor_bytes_transparent.go
+++ b/abi/cbor_bytes_transparent.go
@@ -1,0 +1,20 @@
+package abi
+
+import (
+	"io"
+)
+
+// CborBytesTransparent NOTE This struct does not create a valid cbor-encoded byte slice. It just passes the bytes through as-is.
+type CborBytesTransparent []byte
+
+// MarshalCBOR Does NOT marshall to a cbor-encoding. This is just syntactic sugar to let us pass bytes transparently through lotus which requires a cbor-marshallable object.
+func (t *CborBytesTransparent) MarshalCBOR(w io.Writer) error {
+	_, err := w.Write(*t)
+	return err
+}
+
+// UnmarshalCBOR CANNOT read a cbor-encoded byte slice. This will just transparently pass the underlying bytes.
+func (t *CborBytesTransparent) UnmarshalCBOR(r io.Reader) error {
+	_, err := r.Read(*t)
+	return err
+}

--- a/builtin/v10/account/methods.go
+++ b/builtin/v10/account/methods.go
@@ -11,5 +11,5 @@ var Methods = map[uint64]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*address.Address) *abi.EmptyValue)},                   // Constructor
 	2: {"PubkeyAddress", *new(func(*abi.EmptyValue) *address.Address)},                 // PubkeyAddress
 	3: {"AuthenticateMessage", *new(func(*AuthenticateMessageParams) *abi.EmptyValue)}, // AuthenticateMessage
-	uint64(builtin.UniversalReceiverHookMethodNum): {"UniversalReceiverHook", *new(func(*[]byte) *abi.EmptyValue)}, // UniversalReceiverHook
+	uint64(builtin.UniversalReceiverHookMethodNum): {"UniversalReceiverHook", *new(func(*abi.CborBytesTransparent) *abi.EmptyValue)}, // UniversalReceiverHook
 }

--- a/builtin/v10/multisig/methods.go
+++ b/builtin/v10/multisig/methods.go
@@ -15,5 +15,5 @@ var Methods = map[uint64]builtin.MethodMeta{
 	7: {"SwapSigner", *new(func(*SwapSignerParams) *abi.EmptyValue)},                                   // SwapSigner
 	8: {"ChangeNumApprovalsThreshold", *new(func(*ChangeNumApprovalsThresholdParams) *abi.EmptyValue)}, // ChangeNumApprovalsThreshold
 	9: {"LockBalance", *new(func(*LockBalanceParams) *abi.EmptyValue)},                                 // LockBalance
-	uint64(builtin.UniversalReceiverHookMethodNum): {"UniversalReceiverHook", *new(func(*[]byte) *abi.EmptyValue)}, // UniversalReceiverHook
+	uint64(builtin.UniversalReceiverHookMethodNum): {"UniversalReceiverHook", *new(func(*abi.CborBytesTransparent) *abi.EmptyValue)}, // UniversalReceiverHook
 }

--- a/builtin/v9/account/methods.go
+++ b/builtin/v9/account/methods.go
@@ -11,5 +11,5 @@ var Methods = map[uint64]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*address.Address) *abi.EmptyValue)},                   // Constructor
 	2: {"PubkeyAddress", *new(func(*abi.EmptyValue) *address.Address)},                 // PubkeyAddress
 	3: {"AuthenticateMessage", *new(func(*AuthenticateMessageParams) *abi.EmptyValue)}, // AuthenticateMessage
-	uint64(builtin.UniversalReceiverHookMethodNum): {"UniversalReceiverHook", *new(func(*[]byte) *abi.EmptyValue)}, // UniversalReceiverHook
+	uint64(builtin.UniversalReceiverHookMethodNum): {"UniversalReceiverHook", *new(func(*abi.CborBytesTransparent) *abi.EmptyValue)}, // UniversalReceiverHook
 }

--- a/builtin/v9/multisig/methods.go
+++ b/builtin/v9/multisig/methods.go
@@ -15,5 +15,5 @@ var Methods = map[uint64]builtin.MethodMeta{
 	7: {"SwapSigner", *new(func(*SwapSignerParams) *abi.EmptyValue)},                                   // SwapSigner
 	8: {"ChangeNumApprovalsThreshold", *new(func(*ChangeNumApprovalsThresholdParams) *abi.EmptyValue)}, // ChangeNumApprovalsThreshold
 	9: {"LockBalance", *new(func(*LockBalanceParams) *abi.EmptyValue)},                                 // LockBalance
-	uint64(builtin.UniversalReceiverHookMethodNum): {"UniversalReceiverHook", *new(func(*[]byte) *abi.EmptyValue)}, // UniversalReceiverHook
+	uint64(builtin.UniversalReceiverHookMethodNum): {"UniversalReceiverHook", *new(func(*abi.CborBytesTransparent) *abi.EmptyValue)}, // UniversalReceiverHook
 }


### PR DESCRIPTION
Lotus needs a cbor-marshallable data type to pass in here. Both the `Account` and `Multisig` actors ignore the params passed in to `UniversalReceiverHook`, so we will pass `*abi.EmptyValue`.