### PR TITLE
Change method maps to use abi.MethodNum

### DIFF
--- a/builtin/v10/account/methods.go
+++ b/builtin/v10/account/methods.go
@@ -7,9 +7,9 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
-	1: {"Constructor", *new(func(*address.Address) *abi.EmptyValue)},                   // Constructor
-	2: {"PubkeyAddress", *new(func(*abi.EmptyValue) *address.Address)},                 // PubkeyAddress
-	3: {"AuthenticateMessage", *new(func(*AuthenticateMessageParams) *abi.EmptyValue)}, // AuthenticateMessage
-	uint64(builtin.UniversalReceiverHookMethodNum): {"UniversalReceiverHook", *new(func(*abi.CborBytesTransparent) *abi.EmptyValue)}, // UniversalReceiverHook
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
+	1:                                      {"Constructor", *new(func(*address.Address) *abi.EmptyValue)},                    // Constructor
+	2:                                      {"PubkeyAddress", *new(func(*abi.EmptyValue) *address.Address)},                  // PubkeyAddress
+	3:                                      {"AuthenticateMessage", *new(func(*AuthenticateMessageParams) *abi.EmptyValue)},  // AuthenticateMessage
+	builtin.UniversalReceiverHookMethodNum: {"UniversalReceiverHook", *new(func(*abi.CborBytesTransparent) *abi.EmptyValue)}, // UniversalReceiverHook
 }

--- a/builtin/v10/cron/methods.go
+++ b/builtin/v10/cron/methods.go
@@ -5,7 +5,7 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*ConstructorParams) *abi.EmptyValue)}, // Constructor
 	2: {"EpochTick", *new(func(*abi.EmptyValue) *abi.EmptyValue)},      // EpochTick
 }

--- a/builtin/v10/datacap/methods.go
+++ b/builtin/v10/datacap/methods.go
@@ -7,7 +7,7 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*address.Address) *abi.EmptyValue)}, // Constructor
 	2: {"Mint", *new(func(*MintParams) *MintReturn)},                 // Mint
 	3: {"Destroy", *new(func(*DestroyParams) *BurnReturn)},           // Destroy

--- a/builtin/v10/init/methods.go
+++ b/builtin/v10/init/methods.go
@@ -5,7 +5,7 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*ConstructorParams) *abi.EmptyValue)}, // Constructor
 	2: {"Exec", *new(func(*ExecParams) *ExecReturn)},                   // Exec
 	3: {"Exec4", *new(func(*Exec4Params) *ExecReturn)},                 // Exec4

--- a/builtin/v10/market/methods.go
+++ b/builtin/v10/market/methods.go
@@ -7,7 +7,7 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*abi.EmptyValue) *abi.EmptyValue)},                                              // Constructor
 	2: {"AddBalance", *new(func(*address.Address) *abi.EmptyValue)},                                              // AddBalance
 	3: {"WithdrawBalance", *new(func(*WithdrawBalanceParams) *abi.TokenAmount)},                                  // WithdrawBalance

--- a/builtin/v10/miner/methods.go
+++ b/builtin/v10/miner/methods.go
@@ -9,7 +9,7 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin/v10/power"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1:  {"Constructor", *new(func(*power.MinerConstructorParams) *abi.EmptyValue)},            // Constructor
 	2:  {"ControlAddresses", *new(func(*abi.EmptyValue) *GetControlAddressesReturn)},          // ControlAddresses
 	3:  {"ChangeWorkerAddress", *new(func(*ChangeWorkerAddressParams) *abi.EmptyValue)},       // ChangeWorkerAddress

--- a/builtin/v10/multisig/methods.go
+++ b/builtin/v10/multisig/methods.go
@@ -5,15 +5,15 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
-	1: {"Constructor", *new(func(*ConstructorParams) *abi.EmptyValue)},                                 // Constructor
-	2: {"Propose", *new(func(*ProposeParams) *ProposeReturn)},                                          // Propose
-	3: {"Approve", *new(func(*TxnIDParams) *ApproveReturn)},                                            // Approve
-	4: {"Cancel", *new(func(*TxnIDParams) *abi.EmptyValue)},                                            // Cancel
-	5: {"AddSigner", *new(func(*AddSignerParams) *abi.EmptyValue)},                                     // AddSigner
-	6: {"RemoveSigner", *new(func(*RemoveSignerParams) *abi.EmptyValue)},                               // RemoveSigner
-	7: {"SwapSigner", *new(func(*SwapSignerParams) *abi.EmptyValue)},                                   // SwapSigner
-	8: {"ChangeNumApprovalsThreshold", *new(func(*ChangeNumApprovalsThresholdParams) *abi.EmptyValue)}, // ChangeNumApprovalsThreshold
-	9: {"LockBalance", *new(func(*LockBalanceParams) *abi.EmptyValue)},                                 // LockBalance
-	uint64(builtin.UniversalReceiverHookMethodNum): {"UniversalReceiverHook", *new(func(*abi.CborBytesTransparent) *abi.EmptyValue)}, // UniversalReceiverHook
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
+	1:                                      {"Constructor", *new(func(*ConstructorParams) *abi.EmptyValue)},                                 // Constructor
+	2:                                      {"Propose", *new(func(*ProposeParams) *ProposeReturn)},                                          // Propose
+	3:                                      {"Approve", *new(func(*TxnIDParams) *ApproveReturn)},                                            // Approve
+	4:                                      {"Cancel", *new(func(*TxnIDParams) *abi.EmptyValue)},                                            // Cancel
+	5:                                      {"AddSigner", *new(func(*AddSignerParams) *abi.EmptyValue)},                                     // AddSigner
+	6:                                      {"RemoveSigner", *new(func(*RemoveSignerParams) *abi.EmptyValue)},                               // RemoveSigner
+	7:                                      {"SwapSigner", *new(func(*SwapSignerParams) *abi.EmptyValue)},                                   // SwapSigner
+	8:                                      {"ChangeNumApprovalsThreshold", *new(func(*ChangeNumApprovalsThresholdParams) *abi.EmptyValue)}, // ChangeNumApprovalsThreshold
+	9:                                      {"LockBalance", *new(func(*LockBalanceParams) *abi.EmptyValue)},                                 // LockBalance
+	builtin.UniversalReceiverHookMethodNum: {"UniversalReceiverHook", *new(func(*abi.CborBytesTransparent) *abi.EmptyValue)},                // UniversalReceiverHook
 }

--- a/builtin/v10/paych/methods.go
+++ b/builtin/v10/paych/methods.go
@@ -5,7 +5,7 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*ConstructorParams) *abi.EmptyValue)},               // Constructor
 	2: {"UpdateChannelState", *new(func(*UpdateChannelStateParams) *abi.EmptyValue)}, // UpdateChannelState
 	3: {"Settle", *new(func(*abi.EmptyValue) *abi.EmptyValue)},                       // Settle

--- a/builtin/v10/power/methods.go
+++ b/builtin/v10/power/methods.go
@@ -6,7 +6,7 @@ import (
 	"github.com/filecoin-project/go-state-types/proof"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*abi.EmptyValue) *abi.EmptyValue)},                    // Constructor
 	2: {"CreateMiner", *new(func(*CreateMinerParams) *CreateMinerReturn)},              // CreateMiner
 	3: {"UpdateClaimedPower", *new(func(*UpdateClaimedPowerParams) *abi.EmptyValue)},   // UpdateClaimedPower

--- a/builtin/v10/reward/methods.go
+++ b/builtin/v10/reward/methods.go
@@ -5,7 +5,7 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*abi.StoragePower) *abi.EmptyValue)},            // Constructor
 	2: {"AwardBlockReward", *new(func(*AwardBlockRewardParams) *abi.EmptyValue)}, // AwardBlockReward
 	3: {"ThisEpochReward", *new(func(*abi.EmptyValue) *ThisEpochRewardReturn)},   // ThisEpochReward

--- a/builtin/v10/system/methods.go
+++ b/builtin/v10/system/methods.go
@@ -5,6 +5,6 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*abi.EmptyValue) *abi.EmptyValue)}, // Constructor
 }

--- a/builtin/v10/verifreg/methods.go
+++ b/builtin/v10/verifreg/methods.go
@@ -7,18 +7,18 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
-	1:  {"Constructor", *new(func(*address.Address) *abi.EmptyValue)},                                             // Constructor
-	2:  {"AddVerifier", *new(func(*AddVerifierParams) *abi.EmptyValue)},                                           // AddVerifier
-	3:  {"RemoveVerifier", *new(func(*address.Address) *abi.EmptyValue)},                                          // RemoveVerifier
-	4:  {"AddVerifiedClient", *new(func(*AddVerifiedClientParams) *abi.EmptyValue)},                               // AddVerifiedClient
-	5:  {"UseBytes", nil},                                                                                         // deprecated
-	6:  {"RestoreBytes", nil},                                                                                     // deprecated
-	7:  {"RemoveVerifiedClientDataCap", *new(func(*RemoveDataCapParams) *RemoveDataCapReturn)},                    // RemoveVerifiedClientDataCap
-	8:  {"RemoveExpiredAllocations", *new(func(*RemoveExpiredAllocationsParams) *RemoveExpiredAllocationsReturn)}, // RemoveExpiredAllocations
-	9:  {"ClaimAllocations", *new(func(*ClaimAllocationsParams) *ClaimAllocationsReturn)},                         // ClaimAllocations
-	10: {"GetClaims", *new(func(*GetClaimsParams) *GetClaimsReturn)},                                              // GetClaims
-	11: {"ExtendClaimTerms", *new(func(*ExtendClaimTermsParams) *ExtendClaimTermsReturn)},                         // ExtendClaimTerms
-	12: {"RemoveExpiredClaims", *new(func(*RemoveExpiredClaimsParams) *RemoveExpiredClaimsReturn)},                // RemoveExpiredClaims
-	uint64(builtin.UniversalReceiverHookMethodNum): {"UniversalReceiverHook", *new(func(*UniversalReceiverParams) *AllocationsResponse)}, // UniversalReceiverHook
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
+	1:                                      {"Constructor", *new(func(*address.Address) *abi.EmptyValue)},                                             // Constructor
+	2:                                      {"AddVerifier", *new(func(*AddVerifierParams) *abi.EmptyValue)},                                           // AddVerifier
+	3:                                      {"RemoveVerifier", *new(func(*address.Address) *abi.EmptyValue)},                                          // RemoveVerifier
+	4:                                      {"AddVerifiedClient", *new(func(*AddVerifiedClientParams) *abi.EmptyValue)},                               // AddVerifiedClient
+	5:                                      {"UseBytes", nil},                                                                                         // deprecated
+	6:                                      {"RestoreBytes", nil},                                                                                     // deprecated
+	7:                                      {"RemoveVerifiedClientDataCap", *new(func(*RemoveDataCapParams) *RemoveDataCapReturn)},                    // RemoveVerifiedClientDataCap
+	8:                                      {"RemoveExpiredAllocations", *new(func(*RemoveExpiredAllocationsParams) *RemoveExpiredAllocationsReturn)}, // RemoveExpiredAllocations
+	9:                                      {"ClaimAllocations", *new(func(*ClaimAllocationsParams) *ClaimAllocationsReturn)},                         // ClaimAllocations
+	10:                                     {"GetClaims", *new(func(*GetClaimsParams) *GetClaimsReturn)},                                              // GetClaims
+	11:                                     {"ExtendClaimTerms", *new(func(*ExtendClaimTermsParams) *ExtendClaimTermsReturn)},                         // ExtendClaimTerms
+	12:                                     {"RemoveExpiredClaims", *new(func(*RemoveExpiredClaimsParams) *RemoveExpiredClaimsReturn)},                // RemoveExpiredClaims
+	builtin.UniversalReceiverHookMethodNum: {"UniversalReceiverHook", *new(func(*UniversalReceiverParams) *AllocationsResponse)},                      // UniversalReceiverHook
 }

--- a/builtin/v8/account/methods.go
+++ b/builtin/v8/account/methods.go
@@ -7,7 +7,7 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*address.Address) *abi.EmptyValue)},   // Constructor
 	2: {"PubkeyAddress", *new(func(*abi.EmptyValue) *address.Address)}, // PubkeyAddress
 }

--- a/builtin/v8/cron/methods.go
+++ b/builtin/v8/cron/methods.go
@@ -5,7 +5,7 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*ConstructorParams) *abi.EmptyValue)}, // Constructor
 	2: {"EpochTick", *new(func(*abi.EmptyValue) *abi.EmptyValue)},      // EpochTick
 }

--- a/builtin/v8/init/methods.go
+++ b/builtin/v8/init/methods.go
@@ -5,7 +5,7 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*ConstructorParams) *abi.EmptyValue)}, // Constructor
 	2: {"Exec", *new(func(*ExecParams) *ExecReturn)},                   // Exec
 }

--- a/builtin/v8/market/methods.go
+++ b/builtin/v8/market/methods.go
@@ -7,7 +7,7 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*abi.EmptyValue) *abi.EmptyValue)},                                              // Constructor
 	2: {"AddBalance", *new(func(*address.Address) *abi.EmptyValue)},                                              // AddBalance
 	3: {"WithdrawBalance", *new(func(*WithdrawBalanceParams) *abi.TokenAmount)},                                  // WithdrawBalance

--- a/builtin/v8/miner/methods.go
+++ b/builtin/v8/miner/methods.go
@@ -9,7 +9,7 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin/v8/power"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1:  {"Constructor", *new(func(*power.MinerConstructorParams) *abi.EmptyValue)},            // Constructor
 	2:  {"ControlAddresses", *new(func(*abi.EmptyValue) *GetControlAddressesReturn)},          // ControlAddresses
 	3:  {"ChangeWorkerAddress", *new(func(*ChangeWorkerAddressParams) *abi.EmptyValue)},       // ChangeWorkerAddress

--- a/builtin/v8/multisig/methods.go
+++ b/builtin/v8/multisig/methods.go
@@ -5,7 +5,7 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*ConstructorParams) *abi.EmptyValue)},                                 // Constructor
 	2: {"Propose", *new(func(*ProposeParams) *ProposeReturn)},                                          // Propose
 	3: {"Approve", *new(func(*TxnIDParams) *ApproveReturn)},                                            // Approve

--- a/builtin/v8/paych/methods.go
+++ b/builtin/v8/paych/methods.go
@@ -5,7 +5,7 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*ConstructorParams) *abi.EmptyValue)},               // Constructor
 	2: {"UpdateChannelState", *new(func(*UpdateChannelStateParams) *abi.EmptyValue)}, // UpdateChannelState
 	3: {"Settle", *new(func(*abi.EmptyValue) *abi.EmptyValue)},                       // Settle

--- a/builtin/v8/power/methods.go
+++ b/builtin/v8/power/methods.go
@@ -6,7 +6,7 @@ import (
 	"github.com/filecoin-project/go-state-types/proof"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*abi.EmptyValue) *abi.EmptyValue)},                    // Constructor
 	2: {"CreateMiner", *new(func(*CreateMinerParams) *CreateMinerReturn)},              // CreateMiner
 	3: {"UpdateClaimedPower", *new(func(*UpdateClaimedPowerParams) *abi.EmptyValue)},   // UpdateClaimedPower

--- a/builtin/v8/reward/methods.go
+++ b/builtin/v8/reward/methods.go
@@ -5,7 +5,7 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*abi.StoragePower) *abi.EmptyValue)},            // Constructor
 	2: {"AwardBlockReward", *new(func(*AwardBlockRewardParams) *abi.EmptyValue)}, // AwardBlockReward
 	3: {"ThisEpochReward", *new(func(*abi.EmptyValue) *ThisEpochRewardReturn)},   // ThisEpochReward

--- a/builtin/v8/system/methods.go
+++ b/builtin/v8/system/methods.go
@@ -5,6 +5,6 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*abi.EmptyValue) *abi.EmptyValue)}, // Constructor
 }

--- a/builtin/v8/verifreg/methods.go
+++ b/builtin/v8/verifreg/methods.go
@@ -7,7 +7,7 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*address.Address) *abi.EmptyValue)},                          // Constructor
 	2: {"AddVerifier", *new(func(*AddVerifierParams) *abi.EmptyValue)},                        // AddVerifier
 	3: {"RemoveVerifier", *new(func(*address.Address) *abi.EmptyValue)},                       // RemoveVerifier

--- a/builtin/v9/account/methods.go
+++ b/builtin/v9/account/methods.go
@@ -7,9 +7,9 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
-	1: {"Constructor", *new(func(*address.Address) *abi.EmptyValue)},                   // Constructor
-	2: {"PubkeyAddress", *new(func(*abi.EmptyValue) *address.Address)},                 // PubkeyAddress
-	3: {"AuthenticateMessage", *new(func(*AuthenticateMessageParams) *abi.EmptyValue)}, // AuthenticateMessage
-	uint64(builtin.UniversalReceiverHookMethodNum): {"UniversalReceiverHook", *new(func(*abi.CborBytesTransparent) *abi.EmptyValue)}, // UniversalReceiverHook
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
+	1:                                      {"Constructor", *new(func(*address.Address) *abi.EmptyValue)},                    // Constructor
+	2:                                      {"PubkeyAddress", *new(func(*abi.EmptyValue) *address.Address)},                  // PubkeyAddress
+	3:                                      {"AuthenticateMessage", *new(func(*AuthenticateMessageParams) *abi.EmptyValue)},  // AuthenticateMessage
+	builtin.UniversalReceiverHookMethodNum: {"UniversalReceiverHook", *new(func(*abi.CborBytesTransparent) *abi.EmptyValue)}, // UniversalReceiverHook
 }

--- a/builtin/v9/cron/methods.go
+++ b/builtin/v9/cron/methods.go
@@ -5,7 +5,7 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*ConstructorParams) *abi.EmptyValue)}, // Constructor
 	2: {"EpochTick", *new(func(*abi.EmptyValue) *abi.EmptyValue)},      // EpochTick
 }

--- a/builtin/v9/datacap/methods.go
+++ b/builtin/v9/datacap/methods.go
@@ -7,7 +7,7 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*address.Address) *abi.EmptyValue)}, // Constructor
 	2: {"Mint", *new(func(*MintParams) *MintReturn)},                 // Mint
 	3: {"Destroy", *new(func(*DestroyParams) *BurnReturn)},           // Destroy

--- a/builtin/v9/init/methods.go
+++ b/builtin/v9/init/methods.go
@@ -5,7 +5,7 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*ConstructorParams) *abi.EmptyValue)}, // Constructor
 	2: {"Exec", *new(func(*ExecParams) *ExecReturn)},                   // Exec
 }

--- a/builtin/v9/market/methods.go
+++ b/builtin/v9/market/methods.go
@@ -7,7 +7,7 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*abi.EmptyValue) *abi.EmptyValue)},                                              // Constructor
 	2: {"AddBalance", *new(func(*address.Address) *abi.EmptyValue)},                                              // AddBalance
 	3: {"WithdrawBalance", *new(func(*WithdrawBalanceParams) *abi.TokenAmount)},                                  // WithdrawBalance

--- a/builtin/v9/miner/methods.go
+++ b/builtin/v9/miner/methods.go
@@ -9,7 +9,7 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin/v9/power"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1:  {"Constructor", *new(func(*power.MinerConstructorParams) *abi.EmptyValue)},            // Constructor
 	2:  {"ControlAddresses", *new(func(*abi.EmptyValue) *GetControlAddressesReturn)},          // ControlAddresses
 	3:  {"ChangeWorkerAddress", *new(func(*ChangeWorkerAddressParams) *abi.EmptyValue)},       // ChangeWorkerAddress

--- a/builtin/v9/multisig/methods.go
+++ b/builtin/v9/multisig/methods.go
@@ -5,15 +5,15 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
-	1: {"Constructor", *new(func(*ConstructorParams) *abi.EmptyValue)},                                 // Constructor
-	2: {"Propose", *new(func(*ProposeParams) *ProposeReturn)},                                          // Propose
-	3: {"Approve", *new(func(*TxnIDParams) *ApproveReturn)},                                            // Approve
-	4: {"Cancel", *new(func(*TxnIDParams) *abi.EmptyValue)},                                            // Cancel
-	5: {"AddSigner", *new(func(*AddSignerParams) *abi.EmptyValue)},                                     // AddSigner
-	6: {"RemoveSigner", *new(func(*RemoveSignerParams) *abi.EmptyValue)},                               // RemoveSigner
-	7: {"SwapSigner", *new(func(*SwapSignerParams) *abi.EmptyValue)},                                   // SwapSigner
-	8: {"ChangeNumApprovalsThreshold", *new(func(*ChangeNumApprovalsThresholdParams) *abi.EmptyValue)}, // ChangeNumApprovalsThreshold
-	9: {"LockBalance", *new(func(*LockBalanceParams) *abi.EmptyValue)},                                 // LockBalance
-	uint64(builtin.UniversalReceiverHookMethodNum): {"UniversalReceiverHook", *new(func(*abi.CborBytesTransparent) *abi.EmptyValue)}, // UniversalReceiverHook
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
+	1:                                      {"Constructor", *new(func(*ConstructorParams) *abi.EmptyValue)},                                 // Constructor
+	2:                                      {"Propose", *new(func(*ProposeParams) *ProposeReturn)},                                          // Propose
+	3:                                      {"Approve", *new(func(*TxnIDParams) *ApproveReturn)},                                            // Approve
+	4:                                      {"Cancel", *new(func(*TxnIDParams) *abi.EmptyValue)},                                            // Cancel
+	5:                                      {"AddSigner", *new(func(*AddSignerParams) *abi.EmptyValue)},                                     // AddSigner
+	6:                                      {"RemoveSigner", *new(func(*RemoveSignerParams) *abi.EmptyValue)},                               // RemoveSigner
+	7:                                      {"SwapSigner", *new(func(*SwapSignerParams) *abi.EmptyValue)},                                   // SwapSigner
+	8:                                      {"ChangeNumApprovalsThreshold", *new(func(*ChangeNumApprovalsThresholdParams) *abi.EmptyValue)}, // ChangeNumApprovalsThreshold
+	9:                                      {"LockBalance", *new(func(*LockBalanceParams) *abi.EmptyValue)},                                 // LockBalance
+	builtin.UniversalReceiverHookMethodNum: {"UniversalReceiverHook", *new(func(*abi.CborBytesTransparent) *abi.EmptyValue)},                // UniversalReceiverHook
 }

--- a/builtin/v9/paych/methods.go
+++ b/builtin/v9/paych/methods.go
@@ -5,7 +5,7 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*ConstructorParams) *abi.EmptyValue)},               // Constructor
 	2: {"UpdateChannelState", *new(func(*UpdateChannelStateParams) *abi.EmptyValue)}, // UpdateChannelState
 	3: {"Settle", *new(func(*abi.EmptyValue) *abi.EmptyValue)},                       // Settle

--- a/builtin/v9/power/methods.go
+++ b/builtin/v9/power/methods.go
@@ -6,7 +6,7 @@ import (
 	"github.com/filecoin-project/go-state-types/proof"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*abi.EmptyValue) *abi.EmptyValue)},                    // Constructor
 	2: {"CreateMiner", *new(func(*CreateMinerParams) *CreateMinerReturn)},              // CreateMiner
 	3: {"UpdateClaimedPower", *new(func(*UpdateClaimedPowerParams) *abi.EmptyValue)},   // UpdateClaimedPower

--- a/builtin/v9/reward/methods.go
+++ b/builtin/v9/reward/methods.go
@@ -5,7 +5,7 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*abi.StoragePower) *abi.EmptyValue)},            // Constructor
 	2: {"AwardBlockReward", *new(func(*AwardBlockRewardParams) *abi.EmptyValue)}, // AwardBlockReward
 	3: {"ThisEpochReward", *new(func(*abi.EmptyValue) *ThisEpochRewardReturn)},   // ThisEpochReward

--- a/builtin/v9/system/methods.go
+++ b/builtin/v9/system/methods.go
@@ -5,6 +5,6 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*abi.EmptyValue) *abi.EmptyValue)}, // Constructor
 }

--- a/builtin/v9/verifreg/methods.go
+++ b/builtin/v9/verifreg/methods.go
@@ -7,18 +7,18 @@ import (
 	"github.com/filecoin-project/go-state-types/builtin"
 )
 
-var Methods = map[uint64]builtin.MethodMeta{
-	1:  {"Constructor", *new(func(*address.Address) *abi.EmptyValue)},                                             // Constructor
-	2:  {"AddVerifier", *new(func(*AddVerifierParams) *abi.EmptyValue)},                                           // AddVerifier
-	3:  {"RemoveVerifier", *new(func(*address.Address) *abi.EmptyValue)},                                          // RemoveVerifier
-	4:  {"AddVerifiedClient", *new(func(*AddVerifiedClientParams) *abi.EmptyValue)},                               // AddVerifiedClient
-	5:  {"UseBytes", nil},                                                                                         // deprecated
-	6:  {"RestoreBytes", nil},                                                                                     // deprecated
-	7:  {"RemoveVerifiedClientDataCap", *new(func(*RemoveDataCapParams) *RemoveDataCapReturn)},                    // RemoveVerifiedClientDataCap
-	8:  {"RemoveExpiredAllocations", *new(func(*RemoveExpiredAllocationsParams) *RemoveExpiredAllocationsReturn)}, // RemoveExpiredAllocations
-	9:  {"ClaimAllocations", *new(func(*ClaimAllocationsParams) *ClaimAllocationsReturn)},                         // ClaimAllocations
-	10: {"GetClaims", *new(func(*GetClaimsParams) *GetClaimsReturn)},                                              // GetClaims
-	11: {"ExtendClaimTerms", *new(func(*ExtendClaimTermsParams) *ExtendClaimTermsReturn)},                         // ExtendClaimTerms
-	12: {"RemoveExpiredClaims", *new(func(*RemoveExpiredClaimsParams) *RemoveExpiredClaimsReturn)},                // RemoveExpiredClaims
-	uint64(builtin.UniversalReceiverHookMethodNum): {"UniversalReceiverHook", *new(func(*UniversalReceiverParams) *AllocationsResponse)}, // UniversalReceiverHook
+var Methods = map[abi.MethodNum]builtin.MethodMeta{
+	1:                                      {"Constructor", *new(func(*address.Address) *abi.EmptyValue)},                                             // Constructor
+	2:                                      {"AddVerifier", *new(func(*AddVerifierParams) *abi.EmptyValue)},                                           // AddVerifier
+	3:                                      {"RemoveVerifier", *new(func(*address.Address) *abi.EmptyValue)},                                          // RemoveVerifier
+	4:                                      {"AddVerifiedClient", *new(func(*AddVerifiedClientParams) *abi.EmptyValue)},                               // AddVerifiedClient
+	5:                                      {"UseBytes", nil},                                                                                         // deprecated
+	6:                                      {"RestoreBytes", nil},                                                                                     // deprecated
+	7:                                      {"RemoveVerifiedClientDataCap", *new(func(*RemoveDataCapParams) *RemoveDataCapReturn)},                    // RemoveVerifiedClientDataCap
+	8:                                      {"RemoveExpiredAllocations", *new(func(*RemoveExpiredAllocationsParams) *RemoveExpiredAllocationsReturn)}, // RemoveExpiredAllocations
+	9:                                      {"ClaimAllocations", *new(func(*ClaimAllocationsParams) *ClaimAllocationsReturn)},                         // ClaimAllocations
+	10:                                     {"GetClaims", *new(func(*GetClaimsParams) *GetClaimsReturn)},                                              // GetClaims
+	11:                                     {"ExtendClaimTerms", *new(func(*ExtendClaimTermsParams) *ExtendClaimTermsReturn)},                         // ExtendClaimTerms
+	12:                                     {"RemoveExpiredClaims", *new(func(*RemoveExpiredClaimsParams) *RemoveExpiredClaimsReturn)},                // RemoveExpiredClaims
+	builtin.UniversalReceiverHookMethodNum: {"UniversalReceiverHook", *new(func(*UniversalReceiverParams) *AllocationsResponse)},                      // UniversalReceiverHook
 }


### PR DESCRIPTION
Use abi.MethodNum instead of uint64 for method nums for cleanliness.