### PR TITLE
Fix: CborBytesTransparent: Unmarshal correctly

### DIFF
--- a/abi/cbor_bytes_transparent.go
+++ b/abi/cbor_bytes_transparent.go
@@ -14,7 +14,9 @@ func (t *CborBytesTransparent) MarshalCBOR(w io.Writer) error {
 }
 
 // UnmarshalCBOR CANNOT read a cbor-encoded byte slice. This will just transparently pass the underlying bytes.
+// This method is also risky, as it reads unboundedly. Do NOT use it for anything vulnerable.
 func (t *CborBytesTransparent) UnmarshalCBOR(r io.Reader) error {
-	_, err := r.Read(*t)
+	var err error
+	*t, err = io.ReadAll(r)
 	return err
 }

--- a/abi/cbor_test.go
+++ b/abi/cbor_test.go
@@ -1,0 +1,24 @@
+package abi_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-state-types/abi"
+)
+
+func TestCborBytesTransparent(t *testing.T) {
+	tBytes := abi.CborBytesTransparent([]byte{0xde, 0xad, 0xbe, 0xef})
+
+	buf := new(bytes.Buffer)
+	require.NoError(t, tBytes.MarshalCBOR(buf))
+
+	bytesSer := buf.Bytes()
+	require.Equal(t, []byte(tBytes), bytesSer)
+
+	var bytesDeSer abi.CborBytesTransparent
+	require.NoError(t, bytesDeSer.UnmarshalCBOR(bytes.NewReader(tBytes)))
+	require.Equal(t, tBytes, bytesDeSer)
+}


### PR DESCRIPTION
This type has always been broken, it's just never been used.