### PR TITLE
fix: EVM::GetBytecode now returns an Option

### DIFF
--- a/builtin/v10/evm/evm_types.go
+++ b/builtin/v10/evm/evm_types.go
@@ -1,9 +1,13 @@
 package evm
 
 import (
+	"io"
+
 	"github.com/ipfs/go-cid"
+	xerrors "golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-state-types/abi"
+	cbg "github.com/whyrusleeping/cbor-gen"
 )
 
 type ConstructorParams struct {
@@ -22,4 +26,44 @@ type DelegateCallParams struct {
 	Input  []byte
 	Caller [20]byte
 	Value  abi.TokenAmount
+}
+
+type GetBytecodeReturn struct {
+	Cid *cid.Cid
+}
+
+func (bc *GetBytecodeReturn) UnmarshalCBOR(r io.Reader) error {
+	if bc == nil {
+		return xerrors.Errorf("cannot unmarshal into nil pointer")
+	}
+
+	br := cbg.GetPeeker(r)
+
+	// reset fields
+	bc.Cid = nil
+
+	// Check if it's null
+	if byte, err := br.ReadByte(); err != nil {
+		return err
+	} else if byte == cbg.CborNull[0] {
+		return nil
+	} else if err := br.UnreadByte(); err != nil {
+		return err
+	}
+
+	c, err := cbg.ReadCid(br)
+	if err != nil {
+		return xerrors.Errorf("failed to read cid field t.OldPtr: %w", err)
+	}
+	bc.Cid = &c
+	return nil
+}
+
+func (bc *GetBytecodeReturn) MarshalCBOR(w io.Writer) error {
+	if bc == nil || bc.Cid == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+
+	return cbg.WriteCid(w, *bc.Cid)
 }

--- a/builtin/v10/evm/evm_types_test.go
+++ b/builtin/v10/evm/evm_types_test.go
@@ -1,0 +1,37 @@
+package evm
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
+	cbg "github.com/whyrusleeping/cbor-gen"
+)
+
+func TestGetBytecodeReturn(t *testing.T) {
+	randomCid, err := cid.Decode("bafy2bzacecu7n7wbtogznrtuuvf73dsz7wasgyneqasksdblxupnyovmtwxxu")
+	require.NoError(t, err)
+
+	var cidbuf bytes.Buffer
+	require.NoError(t, cbg.WriteCid(&cidbuf, randomCid))
+
+	in := &GetBytecodeReturn{
+		Cid: &randomCid,
+	}
+	var buf bytes.Buffer
+	require.NoError(t, in.MarshalCBOR(&buf))
+	require.Equal(t, cidbuf.Bytes(), buf.Bytes())
+
+	var out GetBytecodeReturn
+	require.NoError(t, out.UnmarshalCBOR(&buf))
+	require.Equal(t, &randomCid, out.Cid)
+
+	in.Cid = nil
+	buf.Reset()
+	require.NoError(t, in.MarshalCBOR(&buf))
+	require.Equal(t, cbg.CborNull, buf.Bytes())
+
+	require.NoError(t, out.UnmarshalCBOR(&buf))
+	require.Nil(t, out.Cid)
+}

--- a/builtin/v10/evm/methods.go
+++ b/builtin/v10/evm/methods.go
@@ -3,13 +3,12 @@ package evm
 import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/builtin"
-	typegen "github.com/whyrusleeping/cbor-gen"
 )
 
 var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*ConstructorParams) *abi.EmptyValue)},
 	2: {"Resurrect", *new(func(*ResurrectParams) *abi.EmptyValue)},
-	3: {"GetBytecode", *new(func(*abi.EmptyValue) *typegen.CborCid)},
+	3: {"GetBytecode", *new(func(*abi.EmptyValue) *GetBytecodeReturn)},
 	4: {"GetBytecodeHash", *new(func(*abi.EmptyValue) *abi.CborBytes)},
 	5: {"GetStorageAt", *new(func(*GetStorageAtParams) *abi.CborBytes)},
 	6: {"InvokeContractDelegate", *new(func(params *DelegateCallParams) *abi.CborBytes)},


### PR DESCRIPTION
Unfortunately, this requires a manual CBOR implementation.