### PR TITLE
evm types construct creator is a 20 byte hash

### DIFF
--- a/builtin/v10/evm/evm_types.go
+++ b/builtin/v10/evm/evm_types.go
@@ -11,7 +11,7 @@ import (
 )
 
 type ConstructorParams struct {
-	Creator  []byte
+	Creator  [20]byte
 	Initcode []byte
 }
 


### PR DESCRIPTION
creator is an eth address, so it can be specified as a 20 byte data array