### PR TITLE
feat: incorporate changes to AuthenticateMessage

### DIFF
--- a/builtin/methods.go
+++ b/builtin/methods.go
@@ -10,9 +10,9 @@ const (
 )
 
 var MethodsAccount = struct {
-	Constructor           abi.MethodNum
-	PubkeyAddress         abi.MethodNum
-	AuthenticateMessage   abi.MethodNum
+	Constructor         abi.MethodNum
+	PubkeyAddress       abi.MethodNum
+	AuthenticateMessage abi.MethodNum
 }{
 	MethodConstructor,
 	2,
@@ -394,9 +394,7 @@ var MethodsPlaceholder = struct {
 }
 
 var MethodsEthAccount = struct {
-	Constructor           abi.MethodNum
-	AuthenticateMessage   abi.MethodNum
+	Constructor abi.MethodNum
 }{
 	MethodConstructor,
-	MustGenerateFRCMethodNum("AuthenticateMessage"),
 }

--- a/builtin/v10/account/methods.go
+++ b/builtin/v10/account/methods.go
@@ -2,6 +2,7 @@ package account
 
 import (
 	"github.com/filecoin-project/go-address"
+	typegen "github.com/whyrusleeping/cbor-gen"
 
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/builtin"
@@ -10,5 +11,5 @@ import (
 var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*address.Address) *abi.EmptyValue)},   // Constructor
 	2: {"PubkeyAddress", *new(func(*abi.EmptyValue) *address.Address)}, // PubkeyAddress
-	builtin.MustGenerateFRCMethodNum("AuthenticateMessage"): {"AuthenticateMessage", *new(func(*AuthenticateMessageParams) *abi.EmptyValue)},  // AuthenticateMessage
+	builtin.MustGenerateFRCMethodNum("AuthenticateMessage"): {"AuthenticateMessage", *new(func(*AuthenticateMessageParams) *typegen.CborBool)}, // AuthenticateMessage
 }

--- a/builtin/v10/ethaccount/methods.go
+++ b/builtin/v10/ethaccount/methods.go
@@ -7,5 +7,4 @@ import (
 
 var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(value *abi.EmptyValue) *abi.EmptyValue)},
-	builtin.MustGenerateFRCMethodNum("AuthenticateMessage"): {"AuthenticateMessage", *new(func(*AuthenticateMessageParams) *abi.EmptyValue)},  // AuthenticateMessage
 }

--- a/builtin/v11/account/methods.go
+++ b/builtin/v11/account/methods.go
@@ -2,6 +2,7 @@ package account
 
 import (
 	"github.com/filecoin-project/go-address"
+	typegen "github.com/whyrusleeping/cbor-gen"
 
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/builtin"
@@ -10,5 +11,5 @@ import (
 var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(*address.Address) *abi.EmptyValue)},   // Constructor
 	2: {"PubkeyAddress", *new(func(*abi.EmptyValue) *address.Address)}, // PubkeyAddress
-	builtin.MustGenerateFRCMethodNum("AuthenticateMessage"): {"AuthenticateMessage", *new(func(*AuthenticateMessageParams) *abi.EmptyValue)}, // AuthenticateMessage
+	builtin.MustGenerateFRCMethodNum("AuthenticateMessage"): {"AuthenticateMessage", *new(func(*AuthenticateMessageParams) *typegen.CborBool)}, // AuthenticateMessage
 }

--- a/builtin/v11/ethaccount/methods.go
+++ b/builtin/v11/ethaccount/methods.go
@@ -7,5 +7,4 @@ import (
 
 var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	1: {"Constructor", *new(func(value *abi.EmptyValue) *abi.EmptyValue)},
-	builtin.MustGenerateFRCMethodNum("AuthenticateMessage"): {"AuthenticateMessage", *new(func(*AuthenticateMessageParams) *abi.EmptyValue)}, // AuthenticateMessage
 }


### PR DESCRIPTION
- It now returns a `bool` instead of just erroring on failure https://github.com/filecoin-project/builtin-actors/pull/1216
- It has been removed from EthAccounts https://github.com/filecoin-project/builtin-actors/pull/1217