### PR TITLE
Remove incorrect invariants

### DIFF
--- a/builtin/v11/check.go
+++ b/builtin/v11/check.go
@@ -355,7 +355,9 @@ func CheckMarketAgainstVerifreg(acc *builtin.MessageAccumulator, verifregSummary
 	for allocationId, dealId := range marketSummary.AllocIdToDealId {
 		alloc, found := verifregSummary.Allocations[allocationId]
 		acc.Require(found, "allocation %d not found for pending deal %d", allocationId, dealId)
-
+		if !found {
+			continue
+		}
 		info, found := marketSummary.Deals[dealId]
 		acc.Require(found, "internal invariant error invalid market state references missing deal %d", dealId)
 

--- a/builtin/v11/check.go
+++ b/builtin/v11/check.go
@@ -327,11 +327,8 @@ func CheckVerifregAgainstMiners(acc *builtin.MessageAccumulator, verifregSummary
 		maddr, err := address.NewIDAddress(uint64(claim.Provider))
 		acc.RequireNoError(err, "error creating ID address: %v", err)
 
-		minerSummary, ok := minerSummaries[maddr]
+		_, ok := minerSummaries[maddr]
 		acc.Require(ok, "claim provider %s is not found in miner summaries", maddr)
-
-		// all claims are linked to a valid sector number
-		acc.Require(minerSummary.SectorsWithDeals[claim.Sector], "claim sector number %d not recorded as a sector with deals for miner %s", claim.Sector, maddr)
 	}
 }
 

--- a/builtin/v11/init/invariants.go
+++ b/builtin/v11/init/invariants.go
@@ -63,8 +63,9 @@ func CheckStateInvariants(st *State, tree *builtin.ActorTree, actorCodes map[str
 		acc.RequireNoError(err, "unable to convert actorId %v to id address", actorId)
 		actor, found, err := tree.GetActorV5(idaddr)
 		acc.RequireNoError(err, "unable to retrieve actor with idaddr %v", idaddr)
-		acc.Require(found, "actor not found idaddr %v", idaddr)
-
+		if !found {
+			return nil // this can happen if actor self destructs as init is not informed
+		}
 		if keyAddr.Protocol() == addr.Delegated {
 			acc.Require(canHaveDelegatedAddress(actor, actorCodes), "actor %v not supposed to have a delegated address", idaddr)
 		}


### PR DESCRIPTION
I'm still not 100% sure its right to remove these.  They are definitely incorrect but invariant breaks of these forms are somewhat useful to see in the logs as they indicate particular edge cases that can be confirmed to not be part of the problem.  I think it's probably better to remove them for cleanliness but ideally we'd try to find a way to assert something about the edge cases.  Right now that looks either impossible or difficult hence this PR.