### PR TITLE
fix: Add SynthPoReps to SealProofPoliciesV11

### DIFF
--- a/builtin/sector.go
+++ b/builtin/sector.go
@@ -51,6 +51,22 @@ var SealProofPoliciesV11 = map[stabi.RegisteredSealProof]*SealProofPolicy{
 	stabi.RegisteredSealProof_StackedDrg64GiBV1_1: {
 		SectorMaxLifetime: EpochsInFiveYears,
 	},
+
+	stabi.RegisteredSealProof_StackedDrg2KiBV1_1_Feat_SyntheticPoRep: {
+		SectorMaxLifetime: EpochsInFiveYears,
+	},
+	stabi.RegisteredSealProof_StackedDrg8MiBV1_1_Feat_SyntheticPoRep: {
+		SectorMaxLifetime: EpochsInFiveYears,
+	},
+	stabi.RegisteredSealProof_StackedDrg512MiBV1_1_Feat_SyntheticPoRep: {
+		SectorMaxLifetime: EpochsInFiveYears,
+	},
+	stabi.RegisteredSealProof_StackedDrg32GiBV1_1_Feat_SyntheticPoRep: {
+		SectorMaxLifetime: EpochsInFiveYears,
+	},
+	stabi.RegisteredSealProof_StackedDrg64GiBV1_1_Feat_SyntheticPoRep: {
+		SectorMaxLifetime: EpochsInFiveYears,
+	},
 }
 
 // SectorMaximumLifetime is the maximum duration a sector sealed with this proof may exist between activation and expiration


### PR DESCRIPTION
Add SyntheticPoRep to SealProofPoliciesV11 in builtin/sector.go.

These seems to be missing when we did tests on the Butterfly-network, causing extensions of SynthPoRep sector to fail with:

```
lotus-miner sectors extend 3
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2b987a8]

goroutine 1 [running]:
github.com/filecoin-project/lotus/chain/actors/policy.GetSectorMaxLifetime(...)
	/home/misty/lotus/chain/actors/policy/policy.go:592
main.glob..func74(0xc000b46580)
	/home/misty/lotus/cmd/lotus-miner/sectors.go:1194 +0xfc8
github.com/urfave/cli/v2.(*Command).Run(0xab4e160, 0xc000b46580, {0xc000b45080, 0x2, 0x2})
	/home/misty/go/pkg/mod/github.com/urfave/cli/v2@v2.25.5/command.go:274 +0x9eb
github.com/urfave/cli/v2.(*Command).Run(0xab50260, 0xc000b46440, {0xc000b307e0, 0x3, 0x3})
	/home/misty/go/pkg/mod/github.com/urfave/cli/v2@v2.25.5/command.go:267 +0xc4d
github.com/urfave/cli/v2.(*Command).Run(0xc000981ce0, 0xc000b46080, {0xc000052080, 0x4, 0x4})
	/home/misty/go/pkg/mod/github.com/urfave/cli/v2@v2.25.5/command.go:267 +0xc4d
github.com/urfave/cli/v2.(*App).RunContext(0xc00057ef00, {0x6980fb0?, 0xc000056d30}, {0xc000052080, 0x4, 0x4})
	/home/misty/go/pkg/mod/github.com/urfave/cli/v2@v2.25.5/app.go:332 +0x616
github.com/urfave/cli/v2.(*App).Run(...)
	/home/misty/go/pkg/mod/github.com/urfave/cli/v2@v2.25.5/app.go:309
github.com/filecoin-project/lotus/cli.RunApp(0x524eba0?)
	/home/misty/lotus/cli/helper.go:48 +0x107
main.main()
	/home/misty/lotus/cmd/lotus-miner/main.go:170 +0x113a
```


**Testing plan:**

- [ ] Test that extensions of SynthPoRep sectors now work in dev-net