### PR TITLE
Sector info flags: workaround permissions

### DIFF
--- a/builtin/v12/migration/miner.go
+++ b/builtin/v12/migration/miner.go
@@ -372,16 +372,16 @@ func (m minerMigrator) migrateDeadlines(ctx context.Context, store adt11.Store, 
 }
 
 func migrateSectorInfo(sectorInfo miner11.SectorOnChainInfo) *miner12.SectorOnChainInfo {
-  // For a sector that has not been updated: the Activation is correct and ReplacedSectorAge is zero.
-  // For a sector that has been updated through SnapDeals: Activation is the epoch at which it was upgraded, and ReplacedSectorAge is delta since the true activation.
-  // For a sector that has been updated through the old CC path: Activation is correct
-  // Thus, we want to set:
-  //
-  // PowerBaseEpoch := Activation (in all cases)
-  // Activation := Activation (for non-upgraded sectors and sectors upgraded through old CC path)
-  // Activation := OldActivation - ReplacedSectorAge (for sectors updated through SnapDeals)
-  //
-  // SimpleQAPower field got replaced by flags field. We set the flag SIMPLE_QA_POWER if the sector had the field set to true.
+	// For a sector that has not been updated: the Activation is correct and ReplacedSectorAge is zero.
+	// For a sector that has been updated through SnapDeals: Activation is the epoch at which it was upgraded, and ReplacedSectorAge is delta since the true activation.
+	// For a sector that has been updated through the old CC path: Activation is correct
+	// Thus, we want to set:
+	//
+	// PowerBaseEpoch := Activation (in all cases)
+	// Activation := Activation (for non-upgraded sectors and sectors upgraded through old CC path)
+	// Activation := OldActivation - ReplacedSectorAge (for sectors updated through SnapDeals)
+	//
+	// SimpleQAPower field got replaced by flags field. We set the flag SIMPLE_QA_POWER if the sector had the field set to true.
 
 	powerBaseEpoch := sectorInfo.Activation
 	activationEpoch := sectorInfo.Activation
@@ -389,10 +389,10 @@ func migrateSectorInfo(sectorInfo miner11.SectorOnChainInfo) *miner12.SectorOnCh
 		activationEpoch = sectorInfo.Activation - sectorInfo.ReplacedSectorAge
 	}
 
-  flags := miner12.SectorOnChainInfoFlags(0)
-  if sectorInfo.SimpleQAPower {
-    flags = flags | miner12.SIMPLE_QA_POWER
-  }
+	flags := miner12.SectorOnChainInfoFlags(0)
+	if sectorInfo.SimpleQAPower {
+		flags = flags | miner12.SIMPLE_QA_POWER
+	}
 
 	return &miner12.SectorOnChainInfo{
 		SectorNumber:          sectorInfo.SectorNumber,

--- a/builtin/v12/miner/cbor_gen.go
+++ b/builtin/v12/miner/cbor_gen.go
@@ -1973,16 +1973,12 @@ func (t *SectorOnChainInfo) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
-	// t.Flags (miner.SectorOnChainInfoFlags) (int64)
-	if t.Flags >= 0 {
-		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Flags)); err != nil {
-			return err
-		}
-	} else {
-		if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-t.Flags-1)); err != nil {
-			return err
-		}
+	// t.Flags (miner.SectorOnChainInfoFlags) (uint64)
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Flags)); err != nil {
+		return err
 	}
+
 	return nil
 }
 
@@ -2244,30 +2240,19 @@ func (t *SectorOnChainInfo) UnmarshalCBOR(r io.Reader) (err error) {
 		}
 
 	}
-	// t.Flags (miner.SectorOnChainInfoFlags) (int64)
+	// t.Flags (miner.SectorOnChainInfoFlags) (uint64)
+
 	{
-		maj, extra, err := cr.ReadHeader()
-		var extraI int64
+
+		maj, extra, err = cr.ReadHeader()
 		if err != nil {
 			return err
 		}
-		switch maj {
-		case cbg.MajUnsignedInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 positive overflow")
-			}
-		case cbg.MajNegativeInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 negative oveflow")
-			}
-			extraI = -1 - extraI
-		default:
-			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
 		}
+		t.Flags = SectorOnChainInfoFlags(extra)
 
-		t.Flags = SectorOnChainInfoFlags(extraI)
 	}
 	return nil
 }

--- a/builtin/v12/miner/miner_state.go
+++ b/builtin/v12/miner/miner_state.go
@@ -158,7 +158,7 @@ type SectorPreCommitOnChainInfo struct {
 	PreCommitEpoch   abi.ChainEpoch
 }
 
-type SectorOnChainInfoFlags int64
+type SectorOnChainInfoFlags uint64
 
 const (
 	SIMPLE_QA_POWER  SectorOnChainInfoFlags = 1 << iota // QA power mechanism introduced in FIP-0045
@@ -181,7 +181,7 @@ type SectorOnChainInfo struct {
 	PowerBaseEpoch        abi.ChainEpoch          // Epoch at which this sector's power was most recently updated
 	ReplacedDayReward     abi.TokenAmount         // Day reward of this sector before its power was most recently updated
 	SectorKeyCID          *cid.Cid                // The original SealedSectorCID, only gets set on the first ReplicaUpdate
-  Flags                 SectorOnChainInfoFlags  // Additional flags
+	Flags                 SectorOnChainInfoFlags  // Additional flags
 }
 
 func (st *State) GetInfo(store adt.Store) (*MinerInfo, error) {

--- a/builtin/v12/miner/miner_state.go
+++ b/builtin/v12/miner/miner_state.go
@@ -158,23 +158,30 @@ type SectorPreCommitOnChainInfo struct {
 	PreCommitEpoch   abi.ChainEpoch
 }
 
+type SectorOnChainInfoFlags int64
+
+const (
+	SIMPLE_QA_POWER  SectorOnChainInfoFlags = 1 << iota // QA power mechanism introduced in FIP-0045
+)
+
+
 // Information stored on-chain for a proven sector.
 type SectorOnChainInfo struct {
 	SectorNumber          abi.SectorNumber
 	SealProof             abi.RegisteredSealProof // The seal proof type implies the PoSt proof/s
 	SealedCID             cid.Cid                 // CommR
 	DealIDs               []abi.DealID
-	Activation            abi.ChainEpoch  // Epoch during which the sector proof was accepted
-	Expiration            abi.ChainEpoch  // Epoch during which the sector expires
-	DealWeight            abi.DealWeight  // Integral of active deals over sector lifetime
-	VerifiedDealWeight    abi.DealWeight  // Integral of active verified deals over sector lifetime
-	InitialPledge         abi.TokenAmount // Pledge collected to commit this sector
-	ExpectedDayReward     abi.TokenAmount // Expected one day projection of reward for sector computed at activation time
-	ExpectedStoragePledge abi.TokenAmount // Expected twenty day projection of reward for sector computed at activation time
-	PowerBaseEpoch        abi.ChainEpoch  // Epoch at which this sector's power was most recently updated
-	ReplacedDayReward     abi.TokenAmount // Day reward of this sector before its power was most recently updated
-	SectorKeyCID          *cid.Cid        // The original SealedSectorCID, only gets set on the first ReplicaUpdate
-	SimpleQAPower         bool            // Flag for QA power mechanism introduced in FIP-0045
+	Activation            abi.ChainEpoch          // Epoch during which the sector proof was accepted
+	Expiration            abi.ChainEpoch          // Epoch during which the sector expires
+	DealWeight            abi.DealWeight          // Integral of active deals over sector lifetime
+	VerifiedDealWeight    abi.DealWeight          // Integral of active verified deals over sector lifetime
+	InitialPledge         abi.TokenAmount         // Pledge collected to commit this sector
+	ExpectedDayReward     abi.TokenAmount         // Expected one day projection of reward for sector computed at activation time
+	ExpectedStoragePledge abi.TokenAmount         // Expected twenty day projection of reward for sector computed at activation time
+	PowerBaseEpoch        abi.ChainEpoch          // Epoch at which this sector's power was most recently updated
+	ReplacedDayReward     abi.TokenAmount         // Day reward of this sector before its power was most recently updated
+	SectorKeyCID          *cid.Cid                // The original SealedSectorCID, only gets set on the first ReplicaUpdate
+  Flags                 SectorOnChainInfoFlags  // Additional flags
 }
 
 func (st *State) GetInfo(store adt.Store) (*MinerInfo, error) {


### PR DESCRIPTION
This PR is a duplicate of #212 which is already approved.  We are in an annoying situation where CI jobs from forks were disabled and the author of #212 pushed from a fork and is now afk for a long time.  I enabled building from forks but it doesn't retroactively apply without a push so the next best thing is to file a duplicate and ask for an approval.