### PR TITLE
Update deal state schema to match Rust

### DIFF
--- a/builtin/v12/check.go
+++ b/builtin/v12/check.go
@@ -334,22 +334,6 @@ func CheckVerifregAgainstMiners(acc *builtin.MessageAccumulator, verifregSummary
 }
 
 func CheckMarketAgainstVerifreg(acc *builtin.MessageAccumulator, verifregSummary *verifreg.StateSummary, marketSummary *market.StateSummary) {
-	// all activated verified deals with claim ids reference a claim in verifreg state
-	// note that it is possible for claims to exist with no matching deal if the deal expires
-	for claimId, dealId := range marketSummary.ClaimIdToDealId {
-		claim, found := verifregSummary.Claims[claimId]
-		acc.Require(found, "claim %d not found for activated deal %d", claimId, dealId)
-
-		info, found := marketSummary.Deals[dealId]
-		acc.Require(found, "internal invariant error invalid market state references missing deal %d", dealId)
-
-		providerId, err := address.IDFromAddress(info.Provider)
-		acc.RequireNoError(err, "error getting ID from provider address")
-		acc.Require(abi.ActorID(providerId) == claim.Provider, "mismatches providers %d %d on claim %d and deal %d", providerId, claim.Provider, claimId, dealId)
-
-		acc.Require(info.PieceCid == claim.Data, "mismatches piece cid %s %s on claim %d and deal %d", info.PieceCid, claim.Data, claimId, dealId)
-	}
-
 	// all pending deal allocation ids have an associated allocation
 	// note that it is possible for allocations to exist that don't match any deal
 	// if they are created from a direct DataCap transfer

--- a/builtin/v12/market/cbor_gen.go
+++ b/builtin/v12/market/cbor_gen.go
@@ -108,10 +108,10 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("failed to write cid field t.PendingDealAllocationIds: %w", err)
 	}
 
-	// t.SectorDeals (cid.Cid) (struct)
+	// t.ProviderSectors (cid.Cid) (struct)
 
-	if err := cbg.WriteCid(cw, t.SectorDeals); err != nil {
-		return xerrors.Errorf("failed to write cid field t.SectorDeals: %w", err)
+	if err := cbg.WriteCid(cw, t.ProviderSectors); err != nil {
+		return xerrors.Errorf("failed to write cid field t.ProviderSectors: %w", err)
 	}
 
 	return nil
@@ -290,22 +290,22 @@ func (t *State) UnmarshalCBOR(r io.Reader) (err error) {
 		t.PendingDealAllocationIds = c
 
 	}
-	// t.SectorDeals (cid.Cid) (struct)
+	// t.ProviderSectors (cid.Cid) (struct)
 
 	{
 
 		c, err := cbg.ReadCid(cr)
 		if err != nil {
-			return xerrors.Errorf("failed to read cid field t.SectorDeals: %w", err)
+			return xerrors.Errorf("failed to read cid field t.ProviderSectors: %w", err)
 		}
 
-		t.SectorDeals = c
+		t.ProviderSectors = c
 
 	}
 	return nil
 }
 
-var lengthBufDealState = []byte{132}
+var lengthBufDealState = []byte{133}
 
 func (t *DealState) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -316,6 +316,12 @@ func (t *DealState) MarshalCBOR(w io.Writer) error {
 	cw := cbg.NewCborWriter(w)
 
 	if _, err := cw.Write(lengthBufDealState); err != nil {
+		return err
+	}
+
+	// t.SectorNumber (abi.SectorNumber) (uint64)
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.SectorNumber)); err != nil {
 		return err
 	}
 
@@ -380,10 +386,24 @@ func (t *DealState) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 4 {
+	if extra != 5 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
+	// t.SectorNumber (abi.SectorNumber) (uint64)
+
+	{
+
+		maj, extra, err = cr.ReadHeader()
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.SectorNumber = abi.SectorNumber(extra)
+
+	}
 	// t.SectorStartEpoch (abi.ChainEpoch) (int64)
 	{
 		maj, extra, err := cr.ReadHeader()

--- a/builtin/v12/market/deal.go
+++ b/builtin/v12/market/deal.go
@@ -27,6 +27,7 @@ var PieceCIDPrefix = cid.Prefix{
 }
 
 type DealState struct {
+	SectorNumber     abi.SectorNumber
 	SectorStartEpoch abi.ChainEpoch // -1 if not yet included in proven sector
 	LastUpdatedEpoch abi.ChainEpoch // -1 if deal state never updated
 	SlashEpoch       abi.ChainEpoch // -1 if deal never slashed

--- a/builtin/v12/market/invariants.go
+++ b/builtin/v12/market/invariants.go
@@ -28,7 +28,6 @@ type DealSummary struct {
 type StateSummary struct {
 	Deals                    map[abi.DealID]*DealSummary
 	PendingDealAllocationIds map[abi.DealID]verifreg.AllocationId
-	ClaimIdToDealId          map[verifreg.ClaimId]abi.DealID
 	AllocIdToDealId          map[verifreg.AllocationId]abi.DealID
 	PendingProposalCount     uint64
 	DealStateCount           uint64
@@ -118,7 +117,6 @@ func CheckStateInvariants(st *State, store adt.Store, balance abi.TokenAmount, c
 	}
 
 	dealStateCount := uint64(0)
-	claimIdToDealId := make(map[verifreg.ClaimId]abi.DealID)
 	if dealStates, err := adt.AsArray(store, st.States, StatesAmtBitwidth); err != nil {
 		acc.Addf("error loading deal states: %v", err)
 	} else {
@@ -156,11 +154,6 @@ func CheckStateInvariants(st *State, store adt.Store, balance abi.TokenAmount, c
 			acc.Require(!found, "deal %d has pending allocation", dealID)
 
 			dealStateCount++
-
-			if dealState.VerifiedClaim != verifreg.NoAllocationID {
-				claimIdToDealId[verifreg.ClaimId(dealState.VerifiedClaim)] = abi.DealID(dealID)
-			}
-
 			return nil
 		})
 		acc.RequireNoError(err, "error iterating deal states")
@@ -266,7 +259,6 @@ func CheckStateInvariants(st *State, store adt.Store, balance abi.TokenAmount, c
 		LockTableCount:           lockTableCount,
 		DealOpEpochCount:         dealOpEpochCount,
 		DealOpCount:              dealOpCount,
-		ClaimIdToDealId:          claimIdToDealId,
 		AllocIdToDealId:          allocationIdToDealId,
 	}, acc
 }

--- a/builtin/v12/market/market_state.go
+++ b/builtin/v12/market/market_state.go
@@ -57,7 +57,7 @@ type State struct {
 	PendingDealAllocationIds cid.Cid // HAMT[DealID]AllocationID
 
 	// New mapping of sector IDs to deal IDS, grouped by storage provider.
-	SectorDeals cid.Cid // HAMT[Address]HAMT[SectorNumber]SectorDeals
+	ProviderSectors cid.Cid // HAMT[Address]HAMT[SectorNumber]SectorDeals
 
 }
 

--- a/builtin/v12/migration/top.go
+++ b/builtin/v12/migration/top.go
@@ -158,7 +158,7 @@ func MigrateStateTree(ctx context.Context, store cbor.IpldStore, newManifestCID 
 	// Create the new state
 	newMarketState := market12.State{
 		Proposals:                     oldMarketState.Proposals,
-		States:                        oldMarketState.States,
+		States:                        oldMarketState.States, // FIXME migrate deal states to include sector number
 		PendingProposals:              oldMarketState.PendingProposals,
 		EscrowTable:                   oldMarketState.EscrowTable,
 		LockedTable:                   oldMarketState.LockedTable,
@@ -169,7 +169,7 @@ func MigrateStateTree(ctx context.Context, store cbor.IpldStore, newManifestCID 
 		TotalProviderLockedCollateral: oldMarketState.TotalProviderLockedCollateral,
 		TotalClientStorageFee:         oldMarketState.TotalClientStorageFee,
 		PendingDealAllocationIds:      oldMarketState.PendingDealAllocationIds,
-		SectorDeals:                   sectorDealIDs, // Updated value
+		ProviderSectors:               sectorDealIDs, // Updated value
 	}
 
 	newMarketStateCid, err := store.Put(ctx, &newMarketState)


### PR DESCRIPTION
#210 doesn't yet include updating the market DealState schema. This PR isn't a complete resolution (I'm no longer familiar with the rest of the migration code), but intended to be cherry-picked or otherwise cloned into #210 as a prompt to migrate those objects.

See https://github.com/filecoin-project/builtin-actors/pull/1347 and https://github.com/filecoin-project/builtin-actors/pull/1403