### PR TITLE
Fix ProveCommit2Return and DealState structs in GST

### DIFF
--- a/builtin/v12/market/cbor_gen.go
+++ b/builtin/v12/market/cbor_gen.go
@@ -319,6 +319,12 @@ func (t *DealState) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
+	// t.SectorNumber (abi.SectorNumber) (uint64)
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.SectorNumber)); err != nil {
+		return err
+	}
+
 	// t.SectorStartEpoch (abi.ChainEpoch) (int64)
 	if t.SectorStartEpoch >= 0 {
 		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.SectorStartEpoch)); err != nil {
@@ -351,13 +357,6 @@ func (t *DealState) MarshalCBOR(w io.Writer) error {
 			return err
 		}
 	}
-
-	// t.VerifiedClaim (verifreg.AllocationId) (uint64)
-
-	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.VerifiedClaim)); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -384,6 +383,20 @@ func (t *DealState) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
+	// t.SectorNumber (abi.SectorNumber) (uint64)
+
+	{
+
+		maj, extra, err = cr.ReadHeader()
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.SectorNumber = abi.SectorNumber(extra)
+
+	}
 	// t.SectorStartEpoch (abi.ChainEpoch) (int64)
 	{
 		maj, extra, err := cr.ReadHeader()
@@ -458,20 +471,6 @@ func (t *DealState) UnmarshalCBOR(r io.Reader) (err error) {
 		}
 
 		t.SlashEpoch = abi.ChainEpoch(extraI)
-	}
-	// t.VerifiedClaim (verifreg.AllocationId) (uint64)
-
-	{
-
-		maj, extra, err = cr.ReadHeader()
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.VerifiedClaim = verifreg.AllocationId(extra)
-
 	}
 	return nil
 }

--- a/builtin/v12/market/deal.go
+++ b/builtin/v12/market/deal.go
@@ -15,7 +15,6 @@ import (
 	addr "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
-	"github.com/filecoin-project/go-state-types/builtin/v12/verifreg"
 	acrypto "github.com/filecoin-project/go-state-types/crypto"
 )
 
@@ -27,10 +26,10 @@ var PieceCIDPrefix = cid.Prefix{
 }
 
 type DealState struct {
+	SectorNumber     abi.SectorNumber
 	SectorStartEpoch abi.ChainEpoch // -1 if not yet included in proven sector
 	LastUpdatedEpoch abi.ChainEpoch // -1 if deal state never updated
 	SlashEpoch       abi.ChainEpoch // -1 if deal never slashed
-	VerifiedClaim    verifreg.AllocationId
 }
 
 // The DealLabel is a kinded union of string or byte slice.

--- a/builtin/v12/market/invariants.go
+++ b/builtin/v12/market/invariants.go
@@ -157,10 +157,6 @@ func CheckStateInvariants(st *State, store adt.Store, balance abi.TokenAmount, c
 
 			dealStateCount++
 
-			if dealState.VerifiedClaim != verifreg.NoAllocationID {
-				claimIdToDealId[verifreg.ClaimId(dealState.VerifiedClaim)] = abi.DealID(dealID)
-			}
-
 			return nil
 		})
 		acc.RequireNoError(err, "error iterating deal states")

--- a/builtin/v12/miner/cbor_gen.go
+++ b/builtin/v12/miner/cbor_gen.go
@@ -6853,18 +6853,9 @@ func (t *ProveCommit2Return) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.Sectors ([]miner.BatchReturn) (slice)
-	if len(t.Sectors) > cbg.MaxLength {
-		return xerrors.Errorf("Slice value in field t.Sectors was too long")
-	}
-
-	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Sectors))); err != nil {
+	// t.Sectors (miner.BatchReturn) (struct)
+	if err := t.Sectors.MarshalCBOR(cw); err != nil {
 		return err
-	}
-	for _, v := range t.Sectors {
-		if err := v.MarshalCBOR(cw); err != nil {
-			return err
-		}
 	}
 	return nil
 }
@@ -6892,35 +6883,15 @@ func (t *ProveCommit2Return) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.Sectors ([]miner.BatchReturn) (slice)
+	// t.Sectors (miner.BatchReturn) (struct)
 
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
+	{
 
-	if extra > cbg.MaxLength {
-		return fmt.Errorf("t.Sectors: array too large (%d)", extra)
-	}
-
-	if maj != cbg.MajArray {
-		return fmt.Errorf("expected cbor array")
-	}
-
-	if extra > 0 {
-		t.Sectors = make([]BatchReturn, extra)
-	}
-
-	for i := 0; i < int(extra); i++ {
-
-		var v BatchReturn
-		if err := v.UnmarshalCBOR(cr); err != nil {
-			return err
+		if err := t.Sectors.UnmarshalCBOR(cr); err != nil {
+			return xerrors.Errorf("unmarshaling t.Sectors: %w", err)
 		}
 
-		t.Sectors[i] = v
 	}
-
 	return nil
 }
 

--- a/builtin/v12/miner/miner_types.go
+++ b/builtin/v12/miner/miner_types.go
@@ -435,7 +435,7 @@ type DataActivationNotification struct {
 
 // ProveCommit2Return represents the return value for the ProveCommit2 function.
 type ProveCommit2Return struct {
-	Sectors []BatchReturn
+	Sectors BatchReturn
 }
 
 type BatchReturn struct {


### PR DESCRIPTION
- ProveCommit2Return should have a single BatchReturn field (not an array) based on actors code
- DealState adds the SectorNumber field and removes the VerifiedClaim field