### PR TITLE
fix: v12: Update DealMaxDuration to 1278 days

### DIFF
--- a/builtin/v12/market/policy.go
+++ b/builtin/v12/market/policy.go
@@ -17,7 +17,7 @@ var ProviderCollateralSupplyTarget = builtin.BigFrac{
 var DealMinDuration = abi.ChainEpoch(180 * builtin.EpochsInDay) // PARAM_SPEC
 
 // Maximum deal duration
-var DealMaxDuration = abi.ChainEpoch(540 * builtin.EpochsInDay) // PARAM_SPEC
+var DealMaxDuration = abi.ChainEpoch(1278 * builtin.EpochsInDay) // PARAM_SPEC
 
 var MarketDefaultAllocationTermBuffer = abi.ChainEpoch(90 * builtin.EpochsInDay)
 


### PR DESCRIPTION
Update DealMaxDuration to 1278 days to be in-line with [FIP-0052](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0052.md). 