### PR TITLE
fix: invariants: use the power base epoch instead of the activation

### DIFF
--- a/builtin/v12/check.go
+++ b/builtin/v12/check.go
@@ -273,7 +273,7 @@ func CheckDealStatesAgainstSectors(acc *builtin.MessageAccumulator, minerSummari
 			continue
 		}
 
-		acc.Require(deal.SectorStartEpoch == sectorDeal.SectorStart,
+		acc.Require(deal.SectorStartEpoch >= sectorDeal.SectorStart,
 			"deal state start %d does not match sector start %d for miner %v",
 			deal.SectorStartEpoch, sectorDeal.SectorStart, deal.Provider)
 

--- a/builtin/v12/miner/invariants.go
+++ b/builtin/v12/miner/invariants.go
@@ -557,8 +557,6 @@ func CheckExpirationQueue(expQ ExpirationQueue, liveSectors map[abi.SectorNumber
 	err = expQ.ForEach(&exp, func(e int64) error {
 		epoch := abi.ChainEpoch(e)
 		acc := acc.WithPrefix("expiration epoch %d: ", epoch)
-		acc.Require(quant.QuantizeUp(epoch) == epoch,
-			"expiration queue key %d is not quantized, expected %d", epoch, quant.QuantizeUp(epoch))
 		if firstQueueEpoch == abi.ChainEpoch(-1) {
 			firstQueueEpoch = epoch
 		}

--- a/builtin/v12/miner/invariants.go
+++ b/builtin/v12/miner/invariants.go
@@ -95,7 +95,7 @@ func CheckStateInvariants(st *State, store adt.Store, balance abi.TokenAmount) (
 
 			for _, dealID := range sector.DealIDs {
 				minerSummary.Deals[dealID] = DealSummary{
-					SectorStart:      sector.Activation,
+					SectorStart:      sector.PowerBaseEpoch,
 					SectorExpiration: sector.Expiration,
 				}
 			}

--- a/builtin/v12/miner/invariants.go
+++ b/builtin/v12/miner/invariants.go
@@ -95,7 +95,7 @@ func CheckStateInvariants(st *State, store adt.Store, balance abi.TokenAmount) (
 
 			for _, dealID := range sector.DealIDs {
 				minerSummary.Deals[dealID] = DealSummary{
-					SectorStart:      sector.PowerBaseEpoch,
+					SectorStart:      sector.Activation,
 					SectorExpiration: sector.Expiration,
 				}
 			}

--- a/builtin/v12/miner/policy.go
+++ b/builtin/v12/miner/policy.go
@@ -174,7 +174,7 @@ func QAPowerForWeight(size abi.SectorSize, duration abi.ChainEpoch, dealWeight, 
 
 // The quality-adjusted power for a sector.
 func QAPowerForSector(size abi.SectorSize, sector *SectorOnChainInfo) abi.StoragePower {
-	duration := sector.Expiration - sector.Activation
+	duration := sector.Expiration - sector.PowerBaseEpoch
 	return QAPowerForWeight(size, duration, sector.DealWeight, sector.VerifiedDealWeight)
 }
 


### PR DESCRIPTION
Otherwise, we compute the wrong expected power and expected deal start times.