### PR TITLE
clean up go tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/filecoin-project/go-state-types
 
 go 1.13
 
+retract v0.12.7 // wrongfully skipped a patch version, use v0.12.6 or v0.12.8&^
+
 require (
 	github.com/filecoin-project/go-address v1.1.0
 	github.com/filecoin-project/go-amt-ipld/v4 v4.2.0


### PR DESCRIPTION
<img width="261" alt="image" src="https://github.com/filecoin-project/go-state-types/assets/42981373/540f4f66-1824-4af7-8ec5-d70dc65d4b19">
we accidentally skipped a tag which leads to the latest tag v0.12.7 dont have the commit https://github.com/filecoin-project/go-state-types/commit/3d83d7d8dff18d85345e1408a8b8be400058bec1 we want 

to avoid go deps confusion, we are proposing to retract the wrongfully tagged v0.12.7 and once this PR is in we will tag v0.12.8 