### PR TITLE
change the value of duration from endEpoch-startEpoch to sectorExpiry-sectorActivation

### DIFF
--- a/builtin/v12/market/market_state.go
+++ b/builtin/v12/market/market_state.go
@@ -180,7 +180,7 @@ func validateAndComputeDealWeight(proposals *DealArray, dealIDs []abi.DealID, mi
 
 		// Compute deal weight
 		totalDealSpace += uint64(proposal.PieceSize)
-		dealSpaceTime := DealWeight(proposal)
+		dealSpaceTime := DealWeight(proposal, sectorExpiry, sectorActivation)
 		if proposal.VerifiedDeal {
 			totalVerifiedSpaceTime = big.Add(totalVerifiedSpaceTime, dealSpaceTime)
 		} else {

--- a/builtin/v12/market/policy.go
+++ b/builtin/v12/market/policy.go
@@ -55,8 +55,8 @@ func DealClientCollateralBounds(_ abi.PaddedPieceSize, _ abi.ChainEpoch) (min ab
 }
 
 // Computes the weight for a deal proposal, which is a function of its size and duration.
-func DealWeight(proposal *DealProposal) abi.DealWeight {
-	dealDuration := big.NewInt(int64(proposal.Duration()))
+func DealWeight(proposal *DealProposal, sectorExpiry abi.ChainEpoch, sectorActivation abi.ChainEpoch) abi.DealWeight {
+	dealDuration := big.NewInt(int64(sectorExpiry - sectorActivation))
 	dealSize := big.NewIntUnsigned(uint64(proposal.PieceSize))
 	dealSpaceTime := big.Mul(dealDuration, dealSize)
 	return dealSpaceTime

--- a/builtin/v13/market/market_state.go
+++ b/builtin/v13/market/market_state.go
@@ -180,7 +180,7 @@ func validateAndComputeDealWeight(proposals *DealArray, dealIDs []abi.DealID, mi
 
 		// Compute deal weight
 		totalDealSpace += uint64(proposal.PieceSize)
-		dealSpaceTime := DealWeight(proposal)
+		dealSpaceTime := DealWeight(proposal, sectorExpiry, sectorActivation)
 		if proposal.VerifiedDeal {
 			totalVerifiedSpaceTime = big.Add(totalVerifiedSpaceTime, dealSpaceTime)
 		} else {

--- a/builtin/v13/market/policy.go
+++ b/builtin/v13/market/policy.go
@@ -55,8 +55,8 @@ func DealClientCollateralBounds(_ abi.PaddedPieceSize, _ abi.ChainEpoch) (min ab
 }
 
 // Computes the weight for a deal proposal, which is a function of its size and duration.
-func DealWeight(proposal *DealProposal) abi.DealWeight {
-	dealDuration := big.NewInt(int64(proposal.Duration()))
+func DealWeight(proposal *DealProposal, sectorExpiry abi.ChainEpoch, sectorActivation abi.ChainEpoch) abi.DealWeight {
+	dealDuration := big.NewInt(int64(sectorExpiry - sectorActivation))
 	dealSize := big.NewIntUnsigned(uint64(proposal.PieceSize))
 	dealSpaceTime := big.Mul(dealDuration, dealSize)
 	return dealSpaceTime


### PR DESCRIPTION
if the value `endepoch - startepoch` is used as the `duration`, the calculated initial collateral for real deal may be smaller than the actual value, leading to a failed execution of the provecommit msg execution.