### PR TITLE
feat: FIP-0076: implement migration to populate ProviderSectors

### DIFF
--- a/builtin/v10/migration/init.go
+++ b/builtin/v10/migration/init.go
@@ -68,3 +68,7 @@ func (m initActorMigrator) MigrateState(ctx context.Context, store cbor.IpldStor
 		NewHead:    outHead,
 	}, nil
 }
+
+func (m initActorMigrator) Deferred() bool {
+	return false
+}

--- a/builtin/v10/migration/system.go
+++ b/builtin/v10/migration/system.go
@@ -34,3 +34,7 @@ func (m systemActorMigrator) MigrateState(ctx context.Context, store cbor.IpldSt
 		NewHead:    stateHead,
 	}, nil
 }
+
+func (m systemActorMigrator) Deferred() bool {
+	return false
+}

--- a/builtin/v11/migration/miner.go
+++ b/builtin/v11/migration/miner.go
@@ -87,3 +87,7 @@ func (m minerMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, i
 		NewHead:    newHead,
 	}, nil
 }
+
+func (m minerMigrator) Deferred() bool {
+	return false
+}

--- a/builtin/v11/migration/power.go
+++ b/builtin/v11/migration/power.go
@@ -112,3 +112,7 @@ func (m powerMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, i
 		NewHead:    newHead,
 	}, nil
 }
+
+func (m powerMigrator) Deferred() bool {
+	return false
+}

--- a/builtin/v11/migration/system.go
+++ b/builtin/v11/migration/system.go
@@ -34,3 +34,7 @@ func (m systemActorMigrator) MigrateState(ctx context.Context, store cbor.IpldSt
 		NewHead:    stateHead,
 	}, nil
 }
+
+func (m systemActorMigrator) Deferred() bool {
+	return false
+}

--- a/builtin/v12/migration/miner.go
+++ b/builtin/v12/migration/miner.go
@@ -79,6 +79,10 @@ func (m minerMigrator) MigratedCodeCID() cid.Cid {
 	return m.OutCodeCID
 }
 
+func (m minerMigrator) Deferred() bool {
+	return false
+}
+
 func (m minerMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, in migration.ActorMigrationInput) (*migration.ActorMigrationResult, error) {
 	var inState miner11.State
 	if err := store.Get(ctx, in.Head, &inState); err != nil {

--- a/builtin/v12/migration/system.go
+++ b/builtin/v12/migration/system.go
@@ -33,3 +33,7 @@ func (m systemActorMigrator) MigrateState(ctx context.Context, store cbor.IpldSt
 		NewHead:    stateHead,
 	}, nil
 }
+
+func (m systemActorMigrator) Deferred() bool {
+	return false
+}

--- a/builtin/v13/market/invariants.go
+++ b/builtin/v13/market/invariants.go
@@ -265,7 +265,6 @@ func CheckStateInvariants(st *State, store adt.Store, balance abi.TokenAmount, c
 	//
 	// Provider Sectors
 	// Provider->sector->deal mapping
-	// Each entry corresponds to non-terminated deal state.
 	// A deal may have expired but remain in the mapping until settlement.
 
 	providerSectors := make(map[abi.SectorID][]abi.DealID)
@@ -301,7 +300,9 @@ func CheckStateInvariants(st *State, store adt.Store, balance abi.TokenAmount, c
 				// check against proposalStats
 				for _, dealID := range dealIDsCopy {
 					st, found := proposalStats[dealID]
-					acc.Require(found, "deal id %d in provider sectors not found in proposals", dealID)
+					if !found {
+						continue
+					}
 					acc.Require(st.SectorNumber == abi.SectorNumber(sectorNumber), "deal id %d sector number %d does not match sector id %d", dealID, st.SectorNumber, sectorNumber)
 
 					_, ok := expectedProviderSectors[dealID]

--- a/builtin/v13/migration/market.go
+++ b/builtin/v13/migration/market.go
@@ -1,0 +1,409 @@
+package migration
+
+import (
+	"bytes"
+	"context"
+	"errors"
+
+	"github.com/filecoin-project/go-amt-ipld/v4"
+	"github.com/ipfs/go-cid"
+	cbor "github.com/ipfs/go-ipld-cbor"
+	typegen "github.com/whyrusleeping/cbor-gen"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/go-state-types/abi"
+	market12 "github.com/filecoin-project/go-state-types/builtin/v12/market"
+	market13 "github.com/filecoin-project/go-state-types/builtin/v13/market"
+	miner13 "github.com/filecoin-project/go-state-types/builtin/v13/miner"
+	adt13 "github.com/filecoin-project/go-state-types/builtin/v13/util/adt"
+	"github.com/filecoin-project/go-state-types/builtin/v9/util/adt"
+	"github.com/filecoin-project/go-state-types/migration"
+)
+
+var errItemFound = errors.New("item found")
+
+type marketMigrator struct {
+	providerSectors *providerSectors
+	OutCodeCID      cid.Cid
+}
+
+func newMarketMigrator(ctx context.Context, store cbor.IpldStore, outCode cid.Cid, ps *providerSectors) (*marketMigrator, error) {
+	return &marketMigrator{
+		providerSectors: ps,
+		OutCodeCID:      outCode,
+	}, nil
+}
+
+func (m *marketMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, in migration.ActorMigrationInput) (result *migration.ActorMigrationResult, err error) {
+	var inState market12.State
+	if err := store.Get(ctx, in.Head, &inState); err != nil {
+		return nil, xerrors.Errorf("failed to load market state for %s: %w", in.Address, err)
+	}
+
+	providerSectors, newStates, err := m.migrateProviderSectorsAndStates(ctx, store, in, inState.States, inState.Proposals)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to migrate provider sectors: %w", err)
+	}
+
+	outState := market13.State{
+		Proposals:                     inState.Proposals,
+		States:                        newStates,
+		PendingProposals:              inState.PendingProposals,
+		EscrowTable:                   inState.EscrowTable,
+		LockedTable:                   inState.LockedTable,
+		NextID:                        inState.NextID,
+		DealOpsByEpoch:                inState.DealOpsByEpoch,
+		LastCron:                      inState.LastCron,
+		TotalClientLockedCollateral:   inState.TotalClientLockedCollateral,
+		TotalProviderLockedCollateral: inState.TotalProviderLockedCollateral,
+		TotalClientStorageFee:         inState.TotalClientStorageFee,
+		PendingDealAllocationIds:      inState.PendingDealAllocationIds,
+		ProviderSectors:               providerSectors,
+	}
+
+	newHead, err := store.Put(ctx, &outState)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to put new state: %w", err)
+	}
+
+	return &migration.ActorMigrationResult{
+		NewCodeCID: m.MigratedCodeCID(),
+		NewHead:    newHead,
+	}, nil
+}
+
+func (m *marketMigrator) MigratedCodeCID() cid.Cid {
+	return m.OutCodeCID
+}
+
+func (m *marketMigrator) migrateProviderSectorsAndStates(ctx context.Context, store cbor.IpldStore, in migration.ActorMigrationInput, states, proposals cid.Cid) (cid.Cid, cid.Cid, error) {
+	// providerSectorsRoot: HAMT[ActorID]HAMT[SectorNumber]SectorDealIDs
+
+	okIn, prevInStates, err := in.Cache.Read(migration.MarketPrevDealStatesInKey(in.Address))
+	if err != nil {
+		return cid.Undef, cid.Undef, xerrors.Errorf("failed to get previous inRoot from cache: %w", err)
+	}
+
+	okInPr, prevInProposals, err := in.Cache.Read(migration.MarketPrevDealProposalsInKey(in.Address))
+	if err != nil {
+		return cid.Undef, cid.Undef, xerrors.Errorf("failed to get previous inRoot from cache: %w", err)
+	}
+
+	okOut, prevOutStates, err := in.Cache.Read(migration.MarketPrevDealStatesOutKey(in.Address))
+	if err != nil {
+		return cid.Undef, cid.Undef, xerrors.Errorf("failed to get previous outRoot from cache: %w", err)
+	}
+
+	okOutPs, prevOutProviderSectors, err := in.Cache.Read(migration.MarketPrevProviderSectorsOutKey(in.Address))
+	if err != nil {
+		return cid.Undef, cid.Undef, xerrors.Errorf("failed to get previous outRoot from cache: %w", err)
+	}
+
+	var providerSectorsRoot, newStateArrayRoot cid.Cid
+
+	if okIn && okInPr && okOut && okOutPs {
+		providerSectorsRoot, newStateArrayRoot, err = m.migrateProviderSectorsAndStatesWithDiff(ctx, store, prevInStates, prevOutStates, prevOutProviderSectors, states, prevInProposals, proposals)
+		if err != nil {
+			return cid.Undef, cid.Undef, xerrors.Errorf("failed to migrate provider sectors (diff): %w", err)
+		}
+	} else {
+		providerSectorsRoot, newStateArrayRoot, err = m.migrateProviderSectorsAndStatesFromScratch(ctx, store, in, states, proposals)
+		if err != nil {
+			return cid.Undef, cid.Undef, xerrors.Errorf("failed to migrate provider sectors (all): %w", err)
+		}
+	}
+
+	if err := in.Cache.Write(migration.MarketPrevDealStatesInKey(in.Address), states); err != nil {
+		return cid.Undef, cid.Undef, xerrors.Errorf("failed to write previous inRoot to cache: %w", err)
+	}
+
+	if err := in.Cache.Write(migration.MarketPrevDealProposalsInKey(in.Address), proposals); err != nil {
+		return cid.Undef, cid.Undef, xerrors.Errorf("failed to write previous inRoot to cache: %w", err)
+	}
+
+	if err := in.Cache.Write(migration.MarketPrevDealStatesOutKey(in.Address), newStateArrayRoot); err != nil {
+		return cid.Undef, cid.Undef, xerrors.Errorf("failed to write previous outRoot to cache: %w", err)
+	}
+
+	if err := in.Cache.Write(migration.MarketPrevProviderSectorsOutKey(in.Address), providerSectorsRoot); err != nil {
+		return cid.Undef, cid.Undef, xerrors.Errorf("failed to write previous outRoot to cache: %w", err)
+	}
+
+	return providerSectorsRoot, newStateArrayRoot, nil
+}
+
+func (m *marketMigrator) migrateProviderSectorsAndStatesWithDiff(ctx context.Context, store cbor.IpldStore, prevInStatesCid, prevOutStatesCid, prevOutProviderSectorsCid, inStatesCid, prevInProposals, inProposals cid.Cid) (cid.Cid, cid.Cid, error) {
+	statesDiffs, err := amt.Diff(ctx, store, store, prevInStatesCid, inStatesCid, amt.UseTreeBitWidth(market12.StatesAmtBitwidth))
+	if err != nil {
+		return cid.Undef, cid.Undef, xerrors.Errorf("failed to diff old and new deal state AMTs: %w", err)
+	}
+
+	ctxStore := adt.WrapStore(ctx, store)
+
+	prevOutStates, err := adt.AsArray(ctxStore, prevOutStatesCid, market13.StatesAmtBitwidth)
+	if err != nil {
+		return cid.Undef, cid.Undef, xerrors.Errorf("failed to load prevOutStates array: %w", err)
+	}
+
+	prevOutProviderSectors, err := adt.AsMap(ctxStore, prevOutProviderSectorsCid, market13.ProviderSectorsHamtBitwidth)
+	if err != nil {
+		return cid.Undef, cid.Undef, xerrors.Errorf("failed to load prevOutProviderSectors map: %w", err)
+	}
+
+	for _, change := range statesDiffs {
+		deal := abi.DealID(change.Key)
+
+		switch change.Type {
+		case amt.Add:
+			var oldState market12.DealState
+			if err := oldState.UnmarshalCBOR(bytes.NewReader(change.After.Raw)); err != nil {
+				return cid.Cid{}, cid.Cid{}, xerrors.Errorf("failed to unmarshal old state: %w", err)
+			}
+
+			newState := market13.DealState{
+				SectorNumber:     0,
+				SectorStartEpoch: oldState.SectorStartEpoch,
+				LastUpdatedEpoch: oldState.LastUpdatedEpoch,
+				SlashEpoch:       oldState.LastUpdatedEpoch,
+			}
+
+			// TODO: We should technically only set this if the deal hasn't expired,
+			// but if it's a new deal there's no way it's already expired, right?
+			if newState.SlashEpoch == -1 {
+				dealSectorNumber, ok := m.providerSectors.newDealsToSector[deal]
+				if !ok {
+					return cid.Undef, cid.Undef, xerrors.Errorf("didn't find new sector number for new deal %d", deal)
+				}
+				newState.SectorNumber = dealSectorNumber.Number
+			}
+
+			if err := prevOutStates.Set(uint64(deal), &newState); err != nil {
+				return cid.Undef, cid.Undef, xerrors.Errorf("failed to set new state: %w", err)
+			}
+
+		case amt.Remove:
+			if err := prevOutStates.Delete(uint64(deal)); err != nil {
+				return cid.Undef, cid.Undef, xerrors.Errorf("failed to delete new state: %w", err)
+			}
+
+		case amt.Modify:
+
+			var oldState, prevOldState market12.DealState
+			var prevNewState market13.DealState
+			if err := prevOldState.UnmarshalCBOR(bytes.NewReader(change.Before.Raw)); err != nil {
+				return cid.Undef, cid.Undef, xerrors.Errorf("failed to unmarshal old state: %w", err)
+			}
+			if err := oldState.UnmarshalCBOR(bytes.NewReader(change.After.Raw)); err != nil {
+				return cid.Undef, cid.Undef, xerrors.Errorf("failed to unmarshal old state: %w", err)
+			}
+			ok, err := prevOutStates.Get(uint64(deal), &prevNewState)
+			if err != nil {
+				return cid.Undef, cid.Undef, xerrors.Errorf("failed to get previous newstate: %w", err)
+			}
+			if !ok {
+				return cid.Undef, cid.Undef, xerrors.Errorf("failed to get previous newstate: not found")
+			}
+
+			newState := market13.DealState{
+				SectorNumber:     prevNewState.SectorNumber,
+				SectorStartEpoch: oldState.SectorStartEpoch,
+				LastUpdatedEpoch: oldState.LastUpdatedEpoch,
+				SlashEpoch:       oldState.LastUpdatedEpoch,
+			}
+
+			// if the deal is now slashed, UNSET the sector number
+			if newState.SlashEpoch != -1 {
+				newState.SectorNumber = 0
+			}
+
+			if err := prevOutStates.Set(uint64(deal), &newState); err != nil {
+				return cid.Undef, cid.Undef, xerrors.Errorf("failed to set new state: %w", err)
+			}
+		}
+	}
+
+	// now, process updatesToMinerToSectorToDeals, making the appropriate updates
+
+	for miner, sectorUpdates := range m.providerSectors.updatesToMinerToSectorToDeals {
+		var actorSectorsMapRoot typegen.CborCid
+		found, err := prevOutProviderSectors.Get(abi.UIntKey(uint64(miner)), &actorSectorsMapRoot)
+		if err != nil {
+			return cid.Undef, cid.Undef, xerrors.Errorf("failed to get actor sectors: %w", err)
+		}
+
+		var actorSectors *adt13.Map
+		if !found {
+			// can happen, this miner just didn't have any sectors before
+			actorSectors, err = adt13.MakeEmptyMap(ctxStore, market13.ProviderSectorsHamtBitwidth)
+			if err != nil {
+				return cid.Undef, cid.Undef, xerrors.Errorf("failed to make empty actor sectors map: %w", err)
+			}
+		} else {
+			actorSectors, err = adt13.AsMap(ctxStore, cid.Cid(actorSectorsMapRoot), market13.ProviderSectorsHamtBitwidth)
+			if err != nil {
+				return cid.Undef, cid.Undef, xerrors.Errorf("failed to load actor sectors map: %w", err)
+			}
+		}
+
+		var sectorDealIDs market13.SectorDealIDs
+		for sector, deals := range sectorUpdates {
+			// This signals the unlikely case where a sector with deals got GCed after the premigration, delete the entry for it
+			if deals == nil {
+				err = actorSectors.Delete(miner13.SectorKey(sector))
+				if err != nil {
+					return cid.Undef, cid.Undef, xerrors.Errorf("failed to delete actorSectors entry: %w", err)
+				}
+
+				continue
+			} else {
+				sectorDealIDs = deals
+				if err := actorSectors.Put(miner13.SectorKey(sector), &sectorDealIDs); err != nil {
+					return cid.Undef, cid.Undef, xerrors.Errorf("failed to put sector: %w", err)
+				}
+			}
+		}
+
+		// check if actorSectors are empty
+		err = actorSectors.ForEach(nil, func(k string) error {
+			return errItemFound
+		})
+		nonEmpty := false
+		if err == errItemFound {
+			nonEmpty = true
+			err = nil
+		}
+		if err != nil {
+			return cid.Undef, cid.Undef, xerrors.Errorf("failed to iterate actor sectors: %w", err)
+		}
+
+		if nonEmpty {
+			if err := prevOutProviderSectors.Put(abi.UIntKey(uint64(miner)), actorSectors); err != nil {
+				return cid.Undef, cid.Undef, xerrors.Errorf("failed to put actor sectors: %w", err)
+			}
+		} else {
+			if err := prevOutProviderSectors.Delete(abi.UIntKey(uint64(miner))); err != nil {
+				return cid.Undef, cid.Undef, xerrors.Errorf("failed to delete actor sectors: %w", err)
+			}
+		}
+	}
+
+	// flush and return
+	outProviderSectors, err := prevOutProviderSectors.Root()
+	if err != nil {
+		return cid.Undef, cid.Undef, xerrors.Errorf("failed to get providerSectorsRoot: %w", err)
+	}
+
+	outStates, err := prevOutStates.Root()
+	if err != nil {
+		return cid.Undef, cid.Undef, xerrors.Errorf("failed to get statesRoot: %w", err)
+	}
+
+	return outProviderSectors, outStates, nil
+}
+
+func (m *marketMigrator) migrateProviderSectorsAndStatesFromScratch(ctx context.Context, store cbor.IpldStore, in migration.ActorMigrationInput, states cid.Cid, proposals cid.Cid) (cid.Cid, cid.Cid, error) {
+	ctxStore := adt.WrapStore(ctx, store)
+
+	oldStateArray, err := adt.AsArray(ctxStore, states, market12.StatesAmtBitwidth)
+	if err != nil {
+		return cid.Undef, cid.Undef, xerrors.Errorf("failed to load states array: %w", err)
+	}
+
+	newStateArray, err := adt13.MakeEmptyArray(ctxStore, market13.StatesAmtBitwidth)
+	if err != nil {
+		return cid.Undef, cid.Undef, xerrors.Errorf("failed to load states array: %w", err)
+	}
+
+	proposalsArr, err := adt.AsArray(ctxStore, proposals, market12.ProposalsAmtBitwidth)
+	if err != nil {
+		return cid.Undef, cid.Undef, xerrors.Errorf("failed to load proposals array: %w", err)
+	}
+
+	var oldState market12.DealState
+	var newState market13.DealState
+
+	err = oldStateArray.ForEach(&oldState, func(i int64) error {
+		deal := abi.DealID(i)
+
+		newState.SlashEpoch = oldState.SlashEpoch
+		newState.LastUpdatedEpoch = oldState.LastUpdatedEpoch
+		newState.SectorStartEpoch = oldState.SectorStartEpoch
+		newState.SectorNumber = 0 // non- -1 slashed epoch
+
+		var proposal market12.DealProposal
+		ok, err := proposalsArr.Get(uint64(i), &proposal)
+		if err != nil {
+			return xerrors.Errorf("failed to get proposal: %w", err)
+		}
+
+		if !ok {
+			return xerrors.Errorf("failed to find proposal for deal ID %d", i)
+		}
+
+		// FIP: For each unexpired deal state object in the market actor state that has a terminated epoch set to -1:
+		if oldState.SlashEpoch == -1 && proposal.EndEpoch >= UpgradeHeight {
+			// FIP: find the corresponding deal proposal object and extract the provider's actor ID;
+			// - we do this by collecting all dealIDs in providerSectors in miner migration
+
+			// in the provider's miner state, find the ID of the sector with the corresponding deal ID in sector metadata;
+			sid, ok := m.providerSectors.dealToSector[deal]
+			if ok {
+				newState.SectorNumber = sid.Number // FIP: set the new deal state object's sector number to the sector ID found;
+			} else {
+				return xerrors.Errorf("sector not found for unexpired deal %d", i)
+			}
+		}
+
+		if err := newStateArray.Set(uint64(deal), &newState); err != nil {
+			return xerrors.Errorf("failed to append new state: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return cid.Undef, cid.Undef, xerrors.Errorf("failed to iterate states: %w", err)
+	}
+
+	newStateArrayRoot, err := newStateArray.Root()
+	if err != nil {
+		return cid.Undef, cid.Undef, xerrors.Errorf("failed to get newStateArrayRoot: %w", err)
+	}
+
+	outProviderSectors, err := adt.MakeEmptyMap(ctxStore, market13.ProviderSectorsHamtBitwidth)
+	if err != nil {
+		return cid.Undef, cid.Undef, xerrors.Errorf("failed to create empty map: %w", err)
+	}
+
+	for miner, sectors := range m.providerSectors.minerToSectorToDeals {
+		actorSectors, err := adt.MakeEmptyMap(ctxStore, market13.ProviderSectorsHamtBitwidth)
+		if err != nil {
+			return cid.Undef, cid.Undef, xerrors.Errorf("failed to create empty map: %w", err)
+		}
+
+		var sectorDealIDs market13.SectorDealIDs
+		for sector, deals := range sectors {
+			sectorDealIDs = deals
+
+			if err := actorSectors.Put(miner13.SectorKey(sector), &sectorDealIDs); err != nil {
+				return cid.Undef, cid.Undef, xerrors.Errorf("failed to put sector: %w", err)
+			}
+		}
+
+		if err := outProviderSectors.Put(abi.UIntKey(uint64(miner)), actorSectors); err != nil {
+			return cid.Undef, cid.Undef, xerrors.Errorf("failed to put actor sectors: %w", err)
+		}
+	}
+
+	providerSectorsRoot, err := outProviderSectors.Root()
+	if err != nil {
+		return cid.Undef, cid.Undef, xerrors.Errorf("failed to get providerSectorsRoot: %w", err)
+	}
+
+	return providerSectorsRoot, newStateArrayRoot, nil
+}
+
+func (m *marketMigrator) Deferred() bool {
+	return true
+}
+
+var _ migration.ActorMigration = (*marketMigrator)(nil)

--- a/builtin/v13/migration/market.go
+++ b/builtin/v13/migration/market.go
@@ -337,11 +337,12 @@ func (m *marketMigrator) migrateProviderSectorsAndStatesFromScratch(ctx context.
 			sid, ok := m.providerSectors.dealToSector[deal]
 			if ok {
 				newState.SectorNumber = sid.Number // FIP: set the new deal state object's sector number to the sector ID found;
-			} else {
-				// TODO: This SHOULD be a fail if we ever get here, but we seem to do so on mainnet.
-				// The theory is that because of the "ghost deals" bug, but further investigation is needed.
-				//fmt.Println("SUSPECTED GHOST DEAL: ", deal)
 			}
+			//else {
+			// TODO: This SHOULD be a fail if we ever get here, but we seem to do so on mainnet.
+			// The theory is that because of the "ghost deals" bug, but further investigation is needed.
+			//fmt.Println("SUSPECTED GHOST DEAL: ", deal)
+			//}
 		}
 
 		if err := newStateArray.Set(uint64(deal), &newState); err != nil {

--- a/builtin/v13/migration/miner.go
+++ b/builtin/v13/migration/miner.go
@@ -1,0 +1,199 @@
+package migration
+
+import (
+	"context"
+	"sync"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-amt-ipld/v4"
+	"github.com/ipfs/go-cid"
+	cbor "github.com/ipfs/go-ipld-cbor"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/builtin/v13/miner"
+	"github.com/filecoin-project/go-state-types/builtin/v13/util/adt"
+
+	miner12 "github.com/filecoin-project/go-state-types/builtin/v12/miner"
+	"github.com/filecoin-project/go-state-types/migration"
+)
+
+type providerSectors struct {
+	lk sync.Mutex
+
+	// Populated ONLY on the first run-through, when there's no cache to diff against
+	dealToSector         map[abi.DealID]abi.SectorID
+	minerToSectorToDeals map[abi.ActorID]map[abi.SectorNumber][]abi.DealID
+
+	// Populated ONLY on future run-throughs if there is a cache to diff against
+	newDealsToSector              map[abi.DealID]abi.SectorID
+	updatesToMinerToSectorToDeals map[abi.ActorID]map[abi.SectorNumber][]abi.DealID
+}
+
+// minerMigration is technically a no-op, but it collects a cache for market migration
+type minerMigrator struct {
+	providerSectors *providerSectors
+
+	OutCodeCID cid.Cid
+}
+
+func newMinerMigrator(ctx context.Context, store cbor.IpldStore, outCode cid.Cid, ps *providerSectors) (*minerMigrator, error) {
+	return &minerMigrator{
+		providerSectors: ps,
+
+		OutCodeCID: outCode,
+	}, nil
+}
+
+func (m *minerMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, in migration.ActorMigrationInput) (result *migration.ActorMigrationResult, err error) {
+	var inState miner12.State
+	if err := store.Get(ctx, in.Head, &inState); err != nil {
+		return nil, xerrors.Errorf("failed to load miner state for %s: %w", in.Address, err)
+	}
+
+	ctxStore := adt.WrapStore(ctx, store)
+
+	mid, err := address.IDFromAddress(in.Address)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to get miner ID: %w", err)
+	}
+
+	inSectors, err := adt.AsArray(ctxStore, inState.Sectors, miner12.SectorsAmtBitwidth)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to load sectors array: %w", err)
+	}
+
+	hasCached, prevSectors, err := in.Cache.Read(migration.MinerPrevSectorsInKey(in.Address))
+	if err != nil {
+		return nil, xerrors.Errorf("failed to read prev sectors from cache: %w", err)
+	}
+
+	var sector miner.SectorOnChainInfo
+	if !hasCached {
+		// no cached migration, so we simply iterate all sectors and collect deal IDs
+
+		err = inSectors.ForEach(&sector, func(i int64) error {
+			if len(sector.DealIDs) == 0 || sector.Expiration < UpgradeHeight {
+				return nil
+			}
+
+			m.providerSectors.lk.Lock()
+			for _, dealID := range sector.DealIDs {
+				m.providerSectors.dealToSector[dealID] = abi.SectorID{
+					Miner:  abi.ActorID(mid),
+					Number: abi.SectorNumber(i),
+				}
+			}
+
+			sectorDeals, ok := m.providerSectors.minerToSectorToDeals[abi.ActorID(mid)]
+			if !ok {
+				sectorDeals = make(map[abi.SectorNumber][]abi.DealID)
+				m.providerSectors.minerToSectorToDeals[abi.ActorID(mid)] = sectorDeals
+			}
+			// There can't already be an entry for this sector, so just set (not append)
+			// TODO: golang: I need to copy this, since sector is a reference that's constantly updated? Right? Steb?
+			sectorDealIDs := sector.DealIDs
+			sectorDeals[abi.SectorNumber(i)] = sectorDealIDs
+
+			m.providerSectors.lk.Unlock()
+
+			return nil
+		})
+		if err != nil {
+			return nil, xerrors.Errorf("failed to iterate sectors: %w", err)
+		}
+	} else {
+		prevInSectors, err := adt.AsArray(ctxStore, prevSectors, miner12.SectorsAmtBitwidth)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to load previous input sectors array: %w", err)
+		}
+
+		diffs, err := amt.Diff(ctx, store, store, prevSectors, inState.Sectors, amt.UseTreeBitWidth(miner12.SectorsAmtBitwidth))
+		if err != nil {
+			return nil, xerrors.Errorf("failed to diff old and new Sector AMTs: %w", err)
+		}
+
+		for _, change := range diffs {
+			sectorNo := abi.SectorNumber(change.Key)
+
+			switch change.Type {
+			case amt.Add:
+				fallthrough
+			case amt.Modify:
+				found, err := inSectors.Get(change.Key, &sector)
+				if err != nil {
+					return nil, xerrors.Errorf("failed to get sector %d in inSectors: %w", sectorNo, err)
+				}
+
+				if !found {
+					return nil, xerrors.Errorf("didn't find sector %d in inSectors", sectorNo)
+				}
+
+				if len(sector.DealIDs) == 0 {
+					// if no deals don't even bother taking the lock
+					continue
+				}
+
+				m.providerSectors.lk.Lock()
+				for _, dealID := range sector.DealIDs {
+					m.providerSectors.newDealsToSector[dealID] = abi.SectorID{
+						Miner:  abi.ActorID(mid),
+						Number: sectorNo,
+					}
+				}
+
+				sectorDeals, ok := m.providerSectors.updatesToMinerToSectorToDeals[abi.ActorID(mid)]
+				if !ok {
+					sectorDeals = make(map[abi.SectorNumber][]abi.DealID)
+					m.providerSectors.updatesToMinerToSectorToDeals[abi.ActorID(mid)] = sectorDeals
+				}
+				// There can't already be an entry for this sector, so just set (not append)
+				// TODO: golang: I need to copy this, since sector is a reference that's constantly updated? Right? Steb?
+				sectorDealIDs := sector.DealIDs
+				sectorDeals[sectorNo] = sectorDealIDs
+
+				m.providerSectors.lk.Unlock()
+			case amt.Remove:
+				// In this unlikely case, we need to load the deleted SectorOnChainInfo, and mark it as not having any deals
+				var oldSector miner.SectorOnChainInfo
+				found, err := prevInSectors.Get(change.Key, &oldSector)
+				if err != nil {
+					return nil, xerrors.Errorf("failed to get previous sector info: %w", err)
+				}
+				if !found {
+					return nil, xerrors.Errorf("didn't find previous sector info for %d", sectorNo)
+				}
+
+				if len(oldSector.DealIDs) != 0 {
+					sectorDeals, ok := m.providerSectors.updatesToMinerToSectorToDeals[abi.ActorID(mid)]
+					if !ok {
+						sectorDeals = make(map[abi.SectorNumber][]abi.DealID)
+						m.providerSectors.updatesToMinerToSectorToDeals[abi.ActorID(mid)] = sectorDeals
+					}
+					// TODO: Is it better to use nil to communicate deals to be removed, or just a separate map (of maps)?
+					sectorDeals[sectorNo] = nil
+				}
+			}
+		}
+	}
+
+	err = in.Cache.Write(migration.MinerPrevSectorsInKey(in.Address), inState.Sectors)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to write prev sectors to cache: %w", err)
+	}
+
+	return &migration.ActorMigrationResult{
+		NewCodeCID: m.MigratedCodeCID(),
+		NewHead:    in.Head,
+	}, nil
+}
+
+func (m *minerMigrator) MigratedCodeCID() cid.Cid {
+	return m.OutCodeCID
+}
+
+func (m *minerMigrator) Deferred() bool {
+	return false
+}
+
+var _ migration.ActorMigration = (*minerMigrator)(nil)

--- a/builtin/v13/migration/system.go
+++ b/builtin/v13/migration/system.go
@@ -34,3 +34,7 @@ func (m systemActorMigrator) MigrateState(ctx context.Context, store cbor.IpldSt
 		NewHead:    stateHead,
 	}, nil
 }
+
+func (m systemActorMigrator) Deferred() bool {
+	return false
+}

--- a/builtin/v13/migration/top.go
+++ b/builtin/v13/migration/top.go
@@ -17,7 +17,8 @@ import (
 	"golang.org/x/xerrors"
 )
 
-const UpgradeHeight = abi.ChainEpoch(1000)
+// TODO: Make input to migration
+const UpgradeHeight = abi.ChainEpoch(3654004)
 
 // MigrateStateTree Migrates the filecoin state tree starting from the global state tree and upgrading all actor state.
 // The store must support concurrent writes (even if the configured worker count is 1).

--- a/builtin/v13/migration/top.go
+++ b/builtin/v13/migration/top.go
@@ -17,6 +17,8 @@ import (
 	"golang.org/x/xerrors"
 )
 
+const UpgradeHeight = abi.ChainEpoch(1000)
+
 // MigrateStateTree Migrates the filecoin state tree starting from the global state tree and upgrading all actor state.
 // The store must support concurrent writes (even if the configured worker count is 1).
 func MigrateStateTree(ctx context.Context, store cbor.IpldStore, newManifestCID cid.Cid, actorsRootIn cid.Cid, priorEpoch abi.ChainEpoch, cfg migration.Config, log migration.Logger, cache migration.MigrationCache) (cid.Cid, error) {
@@ -67,12 +69,25 @@ func MigrateStateTree(ctx context.Context, store cbor.IpldStore, newManifestCID 
 	// Set of prior version code CIDs for actors to defer during iteration, for explicit migration afterwards.
 	deferredCodeIDs := make(map[cid.Cid]struct{})
 
+	market12Cid := cid.Undef
+	miner12Cid := cid.Undef
+
 	for _, oldEntry := range oldManifestData.Entries {
+		if oldEntry.Name == manifest.MarketKey {
+			market12Cid = oldEntry.Code
+		}
+		if oldEntry.Name == manifest.MinerKey {
+			miner12Cid = oldEntry.Code
+		}
 		newCodeCID, ok := newManifest.Get(oldEntry.Name)
 		if !ok {
 			return cid.Undef, xerrors.Errorf("code cid for %s actor not found in new manifest", oldEntry.Name)
 		}
 		migrations[oldEntry.Code] = migration.CachedMigration(cache, migration.CodeMigrator{OutCodeCID: newCodeCID})
+	}
+
+	if market12Cid == cid.Undef || miner12Cid == cid.Undef {
+		return cid.Undef, xerrors.Errorf("could not find market or miner actor in old manifest")
 	}
 
 	// migrations that migrate both code and state, override entries in `migrations`
@@ -88,6 +103,42 @@ func MigrateStateTree(ctx context.Context, store cbor.IpldStore, newManifestCID 
 
 	if len(migrations)+len(deferredCodeIDs) != len(oldManifestData.Entries) {
 		return cid.Undef, xerrors.Errorf("incomplete migration specification with %d code CIDs, need %d", len(migrations), len(oldManifestData.Entries))
+	}
+
+	// Miner actors
+	miner13Cid, ok := newManifest.Get(manifest.MinerKey)
+	if !ok {
+		return cid.Undef, xerrors.Errorf("code cid for miner actor not found in new manifest")
+	}
+
+	ps := &providerSectors{
+		dealToSector:                  map[abi.DealID]abi.SectorID{},
+		minerToSectorToDeals:          map[abi.ActorID]map[abi.SectorNumber][]abi.DealID{},
+		newDealsToSector:              map[abi.DealID]abi.SectorID{},
+		updatesToMinerToSectorToDeals: map[abi.ActorID]map[abi.SectorNumber][]abi.DealID{},
+	}
+
+	minerMig, err := newMinerMigrator(ctx, store, miner13Cid, ps)
+	if err != nil {
+		return cid.Undef, xerrors.Errorf("failed to create miner migrator: %w", err)
+	}
+
+	migrations[miner12Cid] = migration.CachedMigration(cache, minerMig)
+
+	// The Market Actor
+	market13Cid, ok := newManifest.Get(manifest.MarketKey)
+	if !ok {
+		return cid.Undef, xerrors.Errorf("code cid for market actor not found in new manifest")
+	}
+
+	marketMig, err := newMarketMigrator(ctx, store, market13Cid, ps)
+	if err != nil {
+		return cid.Undef, xerrors.Errorf("failed to create market migrator: %w", err)
+	}
+	migrations[market12Cid] = migration.CachedMigration(cache, marketMig)
+
+	if len(migrations)+len(deferredCodeIDs) != len(oldManifestData.Entries) {
+		return cid.Undef, xerrors.Errorf("incomplete migration specification with %d code CIDs, need %d", len(migrations)+len(deferredCodeIDs), len(oldManifestData.Entries))
 	}
 
 	actorsOut, err := migration.RunMigration(ctx, cfg, cache, store, log, actorsIn, migrations)

--- a/builtin/v13/util/adt/map.go
+++ b/builtin/v13/util/adt/map.go
@@ -3,6 +3,7 @@ package adt
 import (
 	"bytes"
 	"crypto/sha256"
+	"errors"
 	"io"
 
 	cid "github.com/ipfs/go-cid"
@@ -190,5 +191,21 @@ func (m *Map) Pop(k abi.Keyer, out cbor.Unmarshaler) (bool, error) {
 	} else if !found {
 		return false, xerrors.Errorf("failed to find key %v to delete", k.Key())
 	}
+	return true, nil
+}
+
+// IsEmpty returns false if there are any elements in the Map, true otherwise.
+func (m *Map) IsEmpty() (bool, error) {
+	var errItemFound = errors.New("item found")
+	err := m.ForEach(nil, func(k string) error {
+		return errItemFound
+	})
+
+	if err == errItemFound {
+		return false, nil
+	} else if err != nil {
+		return false, xerrors.Errorf("failed to iterate over map: %w", err)
+	}
+
 	return true, nil
 }

--- a/builtin/v13/util/adt/map_test.go
+++ b/builtin/v13/util/adt/map_test.go
@@ -1,0 +1,29 @@
+package adt
+
+import (
+	"context"
+	"testing"
+
+	"github.com/filecoin-project/go-state-types/abi"
+
+	"github.com/filecoin-project/go-state-types/test_util"
+	cbor "github.com/ipfs/go-ipld-cbor"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsEmpty(t *testing.T) {
+	m, err := MakeEmptyMap(WrapStore(context.Background(), cbor.NewCborStore(test_util.NewBlockStoreInMemory())), 5)
+	require.NoError(t, err)
+
+	isEmpty, err := m.IsEmpty()
+	require.NoError(t, err)
+	require.True(t, isEmpty)
+
+	val := abi.CborString("val")
+	require.NoError(t, m.Put(abi.IntKey(5), &val))
+
+	isEmpty, err = m.IsEmpty()
+	require.NoError(t, err)
+	require.False(t, isEmpty)
+}

--- a/builtin/v9/migration/test/migration_test.go
+++ b/builtin/v9/migration/test/migration_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/filecoin-project/go-state-types/test_util"
+
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/manifest"
 	"github.com/ipfs/go-cid"
@@ -19,7 +21,7 @@ import (
 
 func TestMigration(t *testing.T) {
 	ctx := context.Background()
-	bs := cbor.NewCborStore(NewSyncBlockStoreInMemory())
+	bs := cbor.NewCborStore(test_util.NewSyncBlockStoreInMemory())
 	adtStore := adt.WrapStore(ctx, bs)
 
 	startRoot := makeInputTree(ctx, t, adtStore)

--- a/builtin/v9/migration/test/miner_test.go
+++ b/builtin/v9/migration/test/miner_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/filecoin-project/go-state-types/test_util"
+
 	commp "github.com/filecoin-project/go-commp-utils/nonffi"
 	market8 "github.com/filecoin-project/go-state-types/builtin/v8/market"
 
@@ -25,7 +27,7 @@ import (
 
 func TestMinerMigration(t *testing.T) {
 	ctx := context.Background()
-	bs := cbor.NewCborStore(NewSyncBlockStoreInMemory())
+	bs := cbor.NewCborStore(test_util.NewSyncBlockStoreInMemory())
 	adtStore := adt.WrapStore(ctx, bs)
 
 	startRoot := makeInputTree(ctx, t, adtStore)
@@ -317,7 +319,7 @@ func TestMinerMigration(t *testing.T) {
 
 func TestFip0029MinerMigration(t *testing.T) {
 	ctx := context.Background()
-	bs := cbor.NewCborStore(NewSyncBlockStoreInMemory())
+	bs := cbor.NewCborStore(test_util.NewSyncBlockStoreInMemory())
 	adtStore := adt.WrapStore(ctx, bs)
 
 	startRoot := makeInputTree(ctx, t, adtStore)

--- a/builtin/v9/migration/test/parallel_migration_test.go
+++ b/builtin/v9/migration/test/parallel_migration_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/filecoin-project/go-state-types/test_util"
+
 	"github.com/filecoin-project/go-state-types/builtin/v9/util/adt"
 
 	"github.com/filecoin-project/go-state-types/abi"
@@ -18,7 +20,7 @@ func TestParallelMigrationCalls(t *testing.T) {
 	// Construct simple prior state tree over a synchronized store
 	ctx := context.Background()
 	log := TestLogger{TB: t}
-	bs := NewSyncBlockStoreInMemory()
+	bs := test_util.NewSyncBlockStoreInMemory()
 
 	// Run migration
 	adtStore := adt.WrapStore(ctx, cbor.NewCborStore(bs))

--- a/migration/util.go
+++ b/migration/util.go
@@ -141,6 +141,22 @@ func MinerPrevSectorsOutKey(m address.Address) string {
 	return "prevSectorsOut-" + m.String()
 }
 
+func MarketPrevDealStatesInKey(m address.Address) string {
+	return "prevDealStatesIn-" + m.String()
+}
+
+func MarketPrevDealProposalsInKey(m address.Address) string {
+	return "prevDealProposalsIn-" + m.String()
+}
+
+func MarketPrevDealStatesOutKey(m address.Address) string {
+	return "prevDealStatesOut-" + m.String()
+}
+
+func MarketPrevProviderSectorsOutKey(m address.Address) string {
+	return "prevProviderSectorsOut-" + m.String()
+}
+
 type ActorMigrationInput struct {
 	Address address.Address // actor's address
 	Head    cid.Cid
@@ -157,6 +173,9 @@ type ActorMigration interface {
 	// Returns the new state head CID.
 	MigrateState(ctx context.Context, store cbor.IpldStore, input ActorMigrationInput) (result *ActorMigrationResult, err error)
 	MigratedCodeCID() cid.Cid
+
+	// Deferred returns true if this migration should be run after all non-deferred migrations have completed.
+	Deferred() bool
 }
 
 // Migrator which preserves the head CID and provides a fixed result code CID.
@@ -173,6 +192,10 @@ func (n CodeMigrator) MigrateState(_ context.Context, _ cbor.IpldStore, in Actor
 
 func (n CodeMigrator) MigratedCodeCID() cid.Cid {
 	return n.OutCodeCID
+}
+
+func (n CodeMigrator) Deferred() bool {
+	return false
 }
 
 // Migrator that uses cached transformation if it exists
@@ -196,6 +219,10 @@ func (c CachedMigrator) MigrateState(ctx context.Context, store cbor.IpldStore, 
 		NewCodeCID: c.MigratedCodeCID(),
 		NewHead:    newHead,
 	}, nil
+}
+
+func (c CachedMigrator) Deferred() bool {
+	return c.ActorMigration.Deferred()
 }
 
 func CachedMigration(cache MigrationCache, m ActorMigration) ActorMigration {

--- a/test_util/blockstore.go
+++ b/test_util/blockstore.go
@@ -1,0 +1,58 @@
+package test_util
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	block "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+)
+
+type BlockStoreInMemory struct {
+	data map[cid.Cid]block.Block
+}
+
+func NewBlockStoreInMemory() *BlockStoreInMemory {
+	return &BlockStoreInMemory{make(map[cid.Cid]block.Block)}
+}
+
+func (mb *BlockStoreInMemory) Get(ctx context.Context, c cid.Cid) (block.Block, error) {
+	d, ok := mb.data[c]
+	if ok {
+		return d, nil
+	}
+	return nil, fmt.Errorf("not found")
+}
+
+func (mb *BlockStoreInMemory) Put(ctx context.Context, b block.Block) error {
+	mb.data[b.Cid()] = b
+	return nil
+}
+
+type SyncBlockStoreInMemory struct {
+	bs *BlockStoreInMemory
+	mu sync.Mutex
+}
+
+func (ss *SyncBlockStoreInMemory) Context() context.Context {
+	return context.Background()
+}
+
+func NewSyncBlockStoreInMemory() *SyncBlockStoreInMemory {
+	return &SyncBlockStoreInMemory{
+		bs: NewBlockStoreInMemory(),
+	}
+}
+
+func (ss *SyncBlockStoreInMemory) Get(ctx context.Context, c cid.Cid) (block.Block, error) {
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+	return ss.bs.Get(ctx, c)
+}
+
+func (ss *SyncBlockStoreInMemory) Put(ctx context.Context, b block.Block) error {
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+	return ss.bs.Put(ctx, b)
+}


### PR DESCRIPTION
Extracted from #236.

This is a direct copy of the code from there (except for changes made in earlier PRs #245 and #244). I have not yet examined the code for correctness, nor have I addressed some outstanding review on that PR, and so am opening this as draft for now. It effectively needs review including from me.

In particular, reviewers please examine whether the use of the migration cache is incorrect if the "pre-migrated" state is NOT an ancestor of the migration input state. It SHOULD be the case that this is ancestry-agnostic.