### PR TITLE
fix: make ClaimExtensionRequest provider type match builtin-actors

### DIFF
--- a/builtin/v10/verifreg/cbor_gen.go
+++ b/builtin/v10/verifreg/cbor_gen.go
@@ -2947,8 +2947,9 @@ func (t *ClaimExtensionRequest) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.Provider (address.Address) (struct)
-	if err := t.Provider.MarshalCBOR(cw); err != nil {
+	// t.Provider (abi.ActorID) (uint64)
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Provider)); err != nil {
 		return err
 	}
 
@@ -2995,13 +2996,18 @@ func (t *ClaimExtensionRequest) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.Provider (address.Address) (struct)
+	// t.Provider (abi.ActorID) (uint64)
 
 	{
 
-		if err := t.Provider.UnmarshalCBOR(cr); err != nil {
-			return xerrors.Errorf("unmarshaling t.Provider: %w", err)
+		maj, extra, err = cr.ReadHeader()
+		if err != nil {
+			return err
 		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.Provider = abi.ActorID(extra)
 
 	}
 	// t.Claim (verifreg.ClaimId) (uint64)

--- a/builtin/v10/verifreg/verifreg_types.go
+++ b/builtin/v10/verifreg/verifreg_types.go
@@ -217,9 +217,13 @@ type AllocationRequest struct {
 }
 
 type ClaimExtensionRequest struct {
-	Provider addr.Address
-	Claim    ClaimId
-	TermMax  abi.ChainEpoch
+	// The provider (miner actor) which may claim the allocation.
+	Provider abi.ActorID
+	// Identifier of the claim to be extended.
+	Claim ClaimId
+	// The new maximum period for which a provider can earn quality-adjusted power
+	// for the piece (epochs).
+	TermMax abi.ChainEpoch
 }
 
 type AllocationRequests struct {

--- a/builtin/v11/verifreg/cbor_gen.go
+++ b/builtin/v11/verifreg/cbor_gen.go
@@ -2947,8 +2947,9 @@ func (t *ClaimExtensionRequest) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.Provider (address.Address) (struct)
-	if err := t.Provider.MarshalCBOR(cw); err != nil {
+	// t.Provider (abi.ActorID) (uint64)
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Provider)); err != nil {
 		return err
 	}
 
@@ -2995,13 +2996,18 @@ func (t *ClaimExtensionRequest) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.Provider (address.Address) (struct)
+	// t.Provider (abi.ActorID) (uint64)
 
 	{
 
-		if err := t.Provider.UnmarshalCBOR(cr); err != nil {
-			return xerrors.Errorf("unmarshaling t.Provider: %w", err)
+		maj, extra, err = cr.ReadHeader()
+		if err != nil {
+			return err
 		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.Provider = abi.ActorID(extra)
 
 	}
 	// t.Claim (verifreg.ClaimId) (uint64)

--- a/builtin/v11/verifreg/verifreg_types.go
+++ b/builtin/v11/verifreg/verifreg_types.go
@@ -217,9 +217,13 @@ type AllocationRequest struct {
 }
 
 type ClaimExtensionRequest struct {
-	Provider addr.Address
-	Claim    ClaimId
-	TermMax  abi.ChainEpoch
+	// The provider (miner actor) which may claim the allocation.
+	Provider abi.ActorID
+	// Identifier of the claim to be extended.
+	Claim ClaimId
+	// The new maximum period for which a provider can earn quality-adjusted power
+	// for the piece (epochs).
+	TermMax abi.ChainEpoch
 }
 
 type AllocationRequests struct {

--- a/builtin/v12/verifreg/cbor_gen.go
+++ b/builtin/v12/verifreg/cbor_gen.go
@@ -2947,8 +2947,9 @@ func (t *ClaimExtensionRequest) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.Provider (address.Address) (struct)
-	if err := t.Provider.MarshalCBOR(cw); err != nil {
+	// t.Provider (abi.ActorID) (uint64)
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Provider)); err != nil {
 		return err
 	}
 
@@ -2995,13 +2996,18 @@ func (t *ClaimExtensionRequest) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.Provider (address.Address) (struct)
+	// t.Provider (abi.ActorID) (uint64)
 
 	{
 
-		if err := t.Provider.UnmarshalCBOR(cr); err != nil {
-			return xerrors.Errorf("unmarshaling t.Provider: %w", err)
+		maj, extra, err = cr.ReadHeader()
+		if err != nil {
+			return err
 		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.Provider = abi.ActorID(extra)
 
 	}
 	// t.Claim (verifreg.ClaimId) (uint64)

--- a/builtin/v12/verifreg/verifreg_types.go
+++ b/builtin/v12/verifreg/verifreg_types.go
@@ -218,9 +218,13 @@ type AllocationRequest struct {
 }
 
 type ClaimExtensionRequest struct {
-	Provider addr.Address
-	Claim    ClaimId
-	TermMax  abi.ChainEpoch
+	// The provider (miner actor) which may claim the allocation.
+	Provider abi.ActorID
+	// Identifier of the claim to be extended.
+	Claim ClaimId
+	// The new maximum period for which a provider can earn quality-adjusted power
+	// for the piece (epochs).
+	TermMax abi.ChainEpoch
 }
 
 type AllocationRequests struct {

--- a/builtin/v13/verifreg/cbor_gen.go
+++ b/builtin/v13/verifreg/cbor_gen.go
@@ -2947,8 +2947,9 @@ func (t *ClaimExtensionRequest) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.Provider (address.Address) (struct)
-	if err := t.Provider.MarshalCBOR(cw); err != nil {
+	// t.Provider (abi.ActorID) (uint64)
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Provider)); err != nil {
 		return err
 	}
 
@@ -2995,13 +2996,18 @@ func (t *ClaimExtensionRequest) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.Provider (address.Address) (struct)
+	// t.Provider (abi.ActorID) (uint64)
 
 	{
 
-		if err := t.Provider.UnmarshalCBOR(cr); err != nil {
-			return xerrors.Errorf("unmarshaling t.Provider: %w", err)
+		maj, extra, err = cr.ReadHeader()
+		if err != nil {
+			return err
 		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.Provider = abi.ActorID(extra)
 
 	}
 	// t.Claim (verifreg.ClaimId) (uint64)

--- a/builtin/v13/verifreg/verifreg_types.go
+++ b/builtin/v13/verifreg/verifreg_types.go
@@ -218,9 +218,13 @@ type AllocationRequest struct {
 }
 
 type ClaimExtensionRequest struct {
-	Provider addr.Address
-	Claim    ClaimId
-	TermMax  abi.ChainEpoch
+	// The provider (miner actor) which may claim the allocation.
+	Provider abi.ActorID
+	// Identifier of the claim to be extended.
+	Claim ClaimId
+	// The new maximum period for which a provider can earn quality-adjusted power
+	// for the piece (epochs).
+	TermMax abi.ChainEpoch
 }
 
 type AllocationRequests struct {


### PR DESCRIPTION
FIP says Address, builtin-actors says ActorID for both ClaimExtensionRequest and AllocationRequest.

FIP: https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0045.md#creation-of-allocations-and-extension-of-claims-from-datacap-transfer

This mismatch has been in place since v9, but I'm not sure which way this should fall except that `AllocationRequest` has been working as an `ActorID` all this time so we probably don't want to break that.

https://github.com/filecoin-project/go-state-types/pull/76 was filled as per the request was to match builtin-actors in https://github.com/filecoin-project/go-state-types/issues/57. But this PR landed _before_ a change to builtin-actors that switched both of these from `Address` to `ActorID`: https://github.com/filecoin-project/builtin-actors/pull/936. To #76 had it both ways, builtin-actors probably matched the FIP at the time with `Address`, but has been operating as `ActorID` ever since.

My assumption is that we should align these to builtin-actors and do a retroactive FIP of some kind to clarify types of both of these.