### PR TITLE
v13 migration: nit: drop redundant check

### DIFF
--- a/builtin/v13/migration/top.go
+++ b/builtin/v13/migration/top.go
@@ -99,10 +99,6 @@ func MigrateStateTree(ctx context.Context, store cbor.IpldStore, newManifestCID 
 
 	migrations[systemActor.Code] = systemActorMigrator{OutCodeCID: newSystemCodeCID, ManifestData: newManifest.Data}
 
-	if len(migrations)+len(deferredCodeIDs) != len(oldManifestData.Entries) {
-		return cid.Undef, xerrors.Errorf("incomplete migration specification with %d code CIDs, need %d", len(migrations), len(oldManifestData.Entries))
-	}
-
 	// Miner actors
 	miner13Cid, ok := newManifest.Get(manifest.MinerKey)
 	if !ok {


### PR DESCRIPTION
This check is already happening at https://github.com/filecoin-project/go-state-types/compare/asr/test-yushi?expand=1#diff-eb78243bbcd4789a11776f71488d112dcbb5cb16e99d20100501e2a7430b4b2dR134-R136 below, we don't need to do it twice.