### PR TITLE
test: verifreg: add initial cbor encoding forms tests

### DIFF
--- a/builtin/v12/verifreg/verifreg_types_test.go
+++ b/builtin/v12/verifreg/verifreg_types_test.go
@@ -17,24 +17,11 @@ func TestSerializationSlaimAllocationsParams(t *testing.T) {
 		hex    string
 	}{
 		{
-			/*
-			 82                                                # array(2)
-			   80                                              #   array(0)
-			   f4                                              #   false
-			*/
 			params: ClaimAllocationsParams{Sectors: nil, AllOrNothing: false},
-			hex:    "8280f4",
+			// [[],false]
+			hex: "8280f4",
 		},
 		{
-			/*
-			 82                                                # array(2)
-			   81                                              #   array(1)
-			     83                                            #     array(3)
-			       18 65                                       #       uint(101)
-			       18 ca                                       #       uint(202)
-			       80                                          #       array(0)
-			   f5                                              #   true
-			*/
 			params: ClaimAllocationsParams{
 				Sectors: []SectorAllocationClaims{{
 					Sector:       101,
@@ -43,36 +30,10 @@ func TestSerializationSlaimAllocationsParams(t *testing.T) {
 				}},
 				AllOrNothing: true,
 			},
+			// [[[101,202,[]]],true]
 			hex: "828183186518ca80f5",
 		},
 		{
-			/*
-			 82                                                # array(2)
-			   82                                              #   array(2)
-			     83                                            #     array(3)
-			       18 65                                       #       uint(101)
-			       18 ca                                       #       uint(202)
-			       82                                          #       array(2)
-			         84                                        #         array(4)
-			           19 012f                                 #           uint(303)
-			           19 0194                                 #           uint(404)
-			           d8 2a                                   #           tag(42)
-			             49                                    #             bytes(9)
-			               000181e20392200100                  #               "\x00\x01\x81â\x03\x92 \x01\x00"
-			           19 01f9                                 #           uint(505)
-			         84                                        #         array(4)
-			           19 025e                                 #           uint(606)
-			           19 02c3                                 #           uint(707)
-			           d8 2a                                   #           tag(42)
-			             49                                    #             bytes(9)
-			               000181e20392200101                  #               "\x00\x01\x81â\x03\x92 \x01\x01"
-			           19 0328                                 #           uint(808)
-			     83                                            #     array(3)
-			       19 012f                                     #       uint(303)
-			       19 0194                                     #       uint(404)
-			       80                                          #       array(0)
-			   f5                                              #   true
-			*/
 			params: ClaimAllocationsParams{
 				Sectors: []SectorAllocationClaims{{
 					Sector:       101,
@@ -96,6 +57,7 @@ func TestSerializationSlaimAllocationsParams(t *testing.T) {
 				},
 				AllOrNothing: true,
 			},
+			// [[[101,202,[[303,404,baga6ea4seaaqa,505],[606,707,baga6ea4seaaqc,808]]],[303,404,[]]],true]
 			hex: "828283186518ca828419012f190194d82a49000181e203922001001901f98419025e1902c3d82a49000181e203922001011903288319012f19019480f5",
 		},
 	}

--- a/builtin/v12/verifreg/verifreg_types_test.go
+++ b/builtin/v12/verifreg/verifreg_types_test.go
@@ -11,7 +11,7 @@ import (
 
 // Tests to match with Rust fil_actor_verifreg::serialization
 
-func TestSerializationSlaimAllocationsParams(t *testing.T) {
+func TestSerializationClaimAllocationsParams(t *testing.T) {
 	testCases := []struct {
 		params ClaimAllocationsParams
 		hex    string

--- a/builtin/v12/verifreg/verifreg_types_test.go
+++ b/builtin/v12/verifreg/verifreg_types_test.go
@@ -1,0 +1,115 @@
+package verifreg
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests to match with Rust fil_actor_verifreg::serialization
+
+func TestSerializationSlaimAllocationsParams(t *testing.T) {
+	testCases := []struct {
+		params ClaimAllocationsParams
+		hex    string
+	}{
+		{
+			/*
+			 82                                                # array(2)
+			   80                                              #   array(0)
+			   f4                                              #   false
+			*/
+			params: ClaimAllocationsParams{Sectors: nil, AllOrNothing: false},
+			hex:    "8280f4",
+		},
+		{
+			/*
+			 82                                                # array(2)
+			   81                                              #   array(1)
+			     83                                            #     array(3)
+			       18 65                                       #       uint(101)
+			       18 ca                                       #       uint(202)
+			       80                                          #       array(0)
+			   f5                                              #   true
+			*/
+			params: ClaimAllocationsParams{
+				Sectors: []SectorAllocationClaims{{
+					Sector:       101,
+					SectorExpiry: 202,
+					Claims:       nil,
+				}},
+				AllOrNothing: true,
+			},
+			hex: "828183186518ca80f5",
+		},
+		{
+			/*
+			 82                                                # array(2)
+			   82                                              #   array(2)
+			     83                                            #     array(3)
+			       18 65                                       #       uint(101)
+			       18 ca                                       #       uint(202)
+			       82                                          #       array(2)
+			         84                                        #         array(4)
+			           19 012f                                 #           uint(303)
+			           19 0194                                 #           uint(404)
+			           d8 2a                                   #           tag(42)
+			             49                                    #             bytes(9)
+			               000181e20392200100                  #               "\x00\x01\x81â\x03\x92 \x01\x00"
+			           19 01f9                                 #           uint(505)
+			         84                                        #         array(4)
+			           19 025e                                 #           uint(606)
+			           19 02c3                                 #           uint(707)
+			           d8 2a                                   #           tag(42)
+			             49                                    #             bytes(9)
+			               000181e20392200101                  #               "\x00\x01\x81â\x03\x92 \x01\x01"
+			           19 0328                                 #           uint(808)
+			     83                                            #     array(3)
+			       19 012f                                     #       uint(303)
+			       19 0194                                     #       uint(404)
+			       80                                          #       array(0)
+			   f5                                              #   true
+			*/
+			params: ClaimAllocationsParams{
+				Sectors: []SectorAllocationClaims{{
+					Sector:       101,
+					SectorExpiry: 202,
+					Claims: []AllocationClaim{
+						{
+							Client:       303,
+							AllocationId: 404,
+							Data:         cid.MustParse("baga6ea4seaaqa"),
+							Size:         505,
+						},
+						{
+							Client:       606,
+							AllocationId: 707,
+							Data:         cid.MustParse("baga6ea4seaaqc"),
+							Size:         808,
+						},
+					},
+				},
+					{Sector: 303, SectorExpiry: 404, Claims: nil},
+				},
+				AllOrNothing: true,
+			},
+			hex: "828283186518ca828419012f190194d82a49000181e203922001001901f98419025e1902c3d82a49000181e203922001011903288319012f19019480f5",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			req := require.New(t)
+
+			var buf bytes.Buffer
+			req.NoError(tc.params.MarshalCBOR(&buf))
+			req.Equal(tc.hex, hex.EncodeToString(buf.Bytes()))
+			var rt ClaimAllocationsParams
+			req.NoError(rt.UnmarshalCBOR(&buf))
+			req.Equal(tc.params, rt)
+		})
+	}
+}

--- a/builtin/v13/verifreg/verifreg_types_test.go
+++ b/builtin/v13/verifreg/verifreg_types_test.go
@@ -17,24 +17,11 @@ func TestSerializationSlaimAllocationsParams(t *testing.T) {
 		hex    string
 	}{
 		{
-			/*
-			 82                                                # array(2)
-			   80                                              #   array(0)
-			   f4                                              #   false
-			*/
 			params: ClaimAllocationsParams{Sectors: nil, AllOrNothing: false},
-			hex:    "8280f4",
+			// [[],false]
+			hex: "8280f4",
 		},
 		{
-			/*
-			 82                                                # array(2)
-			   81                                              #   array(1)
-			     83                                            #     array(3)
-			       18 65                                       #       uint(101)
-			       18 ca                                       #       uint(202)
-			       80                                          #       array(0)
-			   f5                                              #   true
-			*/
 			params: ClaimAllocationsParams{
 				Sectors: []SectorAllocationClaims{{
 					Sector:       101,
@@ -43,36 +30,10 @@ func TestSerializationSlaimAllocationsParams(t *testing.T) {
 				}},
 				AllOrNothing: true,
 			},
+			// [[[101,202,[]]],true]
 			hex: "828183186518ca80f5",
 		},
 		{
-			/*
-			 82                                                # array(2)
-			   82                                              #   array(2)
-			     83                                            #     array(3)
-			       18 65                                       #       uint(101)
-			       18 ca                                       #       uint(202)
-			       82                                          #       array(2)
-			         84                                        #         array(4)
-			           19 012f                                 #           uint(303)
-			           19 0194                                 #           uint(404)
-			           d8 2a                                   #           tag(42)
-			             49                                    #             bytes(9)
-			               000181e20392200100                  #               "\x00\x01\x81â\x03\x92 \x01\x00"
-			           19 01f9                                 #           uint(505)
-			         84                                        #         array(4)
-			           19 025e                                 #           uint(606)
-			           19 02c3                                 #           uint(707)
-			           d8 2a                                   #           tag(42)
-			             49                                    #             bytes(9)
-			               000181e20392200101                  #               "\x00\x01\x81â\x03\x92 \x01\x01"
-			           19 0328                                 #           uint(808)
-			     83                                            #     array(3)
-			       19 012f                                     #       uint(303)
-			       19 0194                                     #       uint(404)
-			       80                                          #       array(0)
-			   f5                                              #   true
-			*/
 			params: ClaimAllocationsParams{
 				Sectors: []SectorAllocationClaims{{
 					Sector:       101,
@@ -96,6 +57,7 @@ func TestSerializationSlaimAllocationsParams(t *testing.T) {
 				},
 				AllOrNothing: true,
 			},
+			// [[[101,202,[[303,404,baga6ea4seaaqa,505],[606,707,baga6ea4seaaqc,808]]],[303,404,[]]],true]
 			hex: "828283186518ca828419012f190194d82a49000181e203922001001901f98419025e1902c3d82a49000181e203922001011903288319012f19019480f5",
 		},
 	}

--- a/builtin/v13/verifreg/verifreg_types_test.go
+++ b/builtin/v13/verifreg/verifreg_types_test.go
@@ -11,7 +11,7 @@ import (
 
 // Tests to match with Rust fil_actor_verifreg::serialization
 
-func TestSerializationSlaimAllocationsParams(t *testing.T) {
+func TestSerializationClaimAllocationsParams(t *testing.T) {
 	testCases := []struct {
 		params ClaimAllocationsParams
 		hex    string

--- a/builtin/v13/verifreg/verifreg_types_test.go
+++ b/builtin/v13/verifreg/verifreg_types_test.go
@@ -1,0 +1,115 @@
+package verifreg
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests to match with Rust fil_actor_verifreg::serialization
+
+func TestSerializationSlaimAllocationsParams(t *testing.T) {
+	testCases := []struct {
+		params ClaimAllocationsParams
+		hex    string
+	}{
+		{
+			/*
+			 82                                                # array(2)
+			   80                                              #   array(0)
+			   f4                                              #   false
+			*/
+			params: ClaimAllocationsParams{Sectors: nil, AllOrNothing: false},
+			hex:    "8280f4",
+		},
+		{
+			/*
+			 82                                                # array(2)
+			   81                                              #   array(1)
+			     83                                            #     array(3)
+			       18 65                                       #       uint(101)
+			       18 ca                                       #       uint(202)
+			       80                                          #       array(0)
+			   f5                                              #   true
+			*/
+			params: ClaimAllocationsParams{
+				Sectors: []SectorAllocationClaims{{
+					Sector:       101,
+					SectorExpiry: 202,
+					Claims:       nil,
+				}},
+				AllOrNothing: true,
+			},
+			hex: "828183186518ca80f5",
+		},
+		{
+			/*
+			 82                                                # array(2)
+			   82                                              #   array(2)
+			     83                                            #     array(3)
+			       18 65                                       #       uint(101)
+			       18 ca                                       #       uint(202)
+			       82                                          #       array(2)
+			         84                                        #         array(4)
+			           19 012f                                 #           uint(303)
+			           19 0194                                 #           uint(404)
+			           d8 2a                                   #           tag(42)
+			             49                                    #             bytes(9)
+			               000181e20392200100                  #               "\x00\x01\x81â\x03\x92 \x01\x00"
+			           19 01f9                                 #           uint(505)
+			         84                                        #         array(4)
+			           19 025e                                 #           uint(606)
+			           19 02c3                                 #           uint(707)
+			           d8 2a                                   #           tag(42)
+			             49                                    #             bytes(9)
+			               000181e20392200101                  #               "\x00\x01\x81â\x03\x92 \x01\x01"
+			           19 0328                                 #           uint(808)
+			     83                                            #     array(3)
+			       19 012f                                     #       uint(303)
+			       19 0194                                     #       uint(404)
+			       80                                          #       array(0)
+			   f5                                              #   true
+			*/
+			params: ClaimAllocationsParams{
+				Sectors: []SectorAllocationClaims{{
+					Sector:       101,
+					SectorExpiry: 202,
+					Claims: []AllocationClaim{
+						{
+							Client:       303,
+							AllocationId: 404,
+							Data:         cid.MustParse("baga6ea4seaaqa"),
+							Size:         505,
+						},
+						{
+							Client:       606,
+							AllocationId: 707,
+							Data:         cid.MustParse("baga6ea4seaaqc"),
+							Size:         808,
+						},
+					},
+				},
+					{Sector: 303, SectorExpiry: 404, Claims: nil},
+				},
+				AllOrNothing: true,
+			},
+			hex: "828283186518ca828419012f190194d82a49000181e203922001001901f98419025e1902c3d82a49000181e203922001011903288319012f19019480f5",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			req := require.New(t)
+
+			var buf bytes.Buffer
+			req.NoError(tc.params.MarshalCBOR(&buf))
+			req.Equal(tc.hex, hex.EncodeToString(buf.Bytes()))
+			var rt ClaimAllocationsParams
+			req.NoError(rt.UnmarshalCBOR(&buf))
+			req.Equal(tc.params, rt)
+		})
+	}
+}

--- a/builtin/v14/verifreg/verifreg_types_test.go
+++ b/builtin/v14/verifreg/verifreg_types_test.go
@@ -17,24 +17,11 @@ func TestSerializationSlaimAllocationsParams(t *testing.T) {
 		hex    string
 	}{
 		{
-			/*
-			 82                                                # array(2)
-			   80                                              #   array(0)
-			   f4                                              #   false
-			*/
 			params: ClaimAllocationsParams{Sectors: nil, AllOrNothing: false},
-			hex:    "8280f4",
+			// [[],false]
+			hex: "8280f4",
 		},
 		{
-			/*
-			 82                                                # array(2)
-			   81                                              #   array(1)
-			     83                                            #     array(3)
-			       18 65                                       #       uint(101)
-			       18 ca                                       #       uint(202)
-			       80                                          #       array(0)
-			   f5                                              #   true
-			*/
 			params: ClaimAllocationsParams{
 				Sectors: []SectorAllocationClaims{{
 					Sector:       101,
@@ -43,36 +30,10 @@ func TestSerializationSlaimAllocationsParams(t *testing.T) {
 				}},
 				AllOrNothing: true,
 			},
+			// [[[101,202,[]]],true]
 			hex: "828183186518ca80f5",
 		},
 		{
-			/*
-			 82                                                # array(2)
-			   82                                              #   array(2)
-			     83                                            #     array(3)
-			       18 65                                       #       uint(101)
-			       18 ca                                       #       uint(202)
-			       82                                          #       array(2)
-			         84                                        #         array(4)
-			           19 012f                                 #           uint(303)
-			           19 0194                                 #           uint(404)
-			           d8 2a                                   #           tag(42)
-			             49                                    #             bytes(9)
-			               000181e20392200100                  #               "\x00\x01\x81â\x03\x92 \x01\x00"
-			           19 01f9                                 #           uint(505)
-			         84                                        #         array(4)
-			           19 025e                                 #           uint(606)
-			           19 02c3                                 #           uint(707)
-			           d8 2a                                   #           tag(42)
-			             49                                    #             bytes(9)
-			               000181e20392200101                  #               "\x00\x01\x81â\x03\x92 \x01\x01"
-			           19 0328                                 #           uint(808)
-			     83                                            #     array(3)
-			       19 012f                                     #       uint(303)
-			       19 0194                                     #       uint(404)
-			       80                                          #       array(0)
-			   f5                                              #   true
-			*/
 			params: ClaimAllocationsParams{
 				Sectors: []SectorAllocationClaims{{
 					Sector:       101,
@@ -96,6 +57,7 @@ func TestSerializationSlaimAllocationsParams(t *testing.T) {
 				},
 				AllOrNothing: true,
 			},
+			// [[[101,202,[[303,404,baga6ea4seaaqa,505],[606,707,baga6ea4seaaqc,808]]],[303,404,[]]],true]
 			hex: "828283186518ca828419012f190194d82a49000181e203922001001901f98419025e1902c3d82a49000181e203922001011903288319012f19019480f5",
 		},
 	}

--- a/builtin/v14/verifreg/verifreg_types_test.go
+++ b/builtin/v14/verifreg/verifreg_types_test.go
@@ -11,7 +11,7 @@ import (
 
 // Tests to match with Rust fil_actor_verifreg::serialization
 
-func TestSerializationSlaimAllocationsParams(t *testing.T) {
+func TestSerializationClaimAllocationsParams(t *testing.T) {
 	testCases := []struct {
 		params ClaimAllocationsParams
 		hex    string

--- a/builtin/v14/verifreg/verifreg_types_test.go
+++ b/builtin/v14/verifreg/verifreg_types_test.go
@@ -1,0 +1,115 @@
+package verifreg
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests to match with Rust fil_actor_verifreg::serialization
+
+func TestSerializationSlaimAllocationsParams(t *testing.T) {
+	testCases := []struct {
+		params ClaimAllocationsParams
+		hex    string
+	}{
+		{
+			/*
+			 82                                                # array(2)
+			   80                                              #   array(0)
+			   f4                                              #   false
+			*/
+			params: ClaimAllocationsParams{Sectors: nil, AllOrNothing: false},
+			hex:    "8280f4",
+		},
+		{
+			/*
+			 82                                                # array(2)
+			   81                                              #   array(1)
+			     83                                            #     array(3)
+			       18 65                                       #       uint(101)
+			       18 ca                                       #       uint(202)
+			       80                                          #       array(0)
+			   f5                                              #   true
+			*/
+			params: ClaimAllocationsParams{
+				Sectors: []SectorAllocationClaims{{
+					Sector:       101,
+					SectorExpiry: 202,
+					Claims:       nil,
+				}},
+				AllOrNothing: true,
+			},
+			hex: "828183186518ca80f5",
+		},
+		{
+			/*
+			 82                                                # array(2)
+			   82                                              #   array(2)
+			     83                                            #     array(3)
+			       18 65                                       #       uint(101)
+			       18 ca                                       #       uint(202)
+			       82                                          #       array(2)
+			         84                                        #         array(4)
+			           19 012f                                 #           uint(303)
+			           19 0194                                 #           uint(404)
+			           d8 2a                                   #           tag(42)
+			             49                                    #             bytes(9)
+			               000181e20392200100                  #               "\x00\x01\x81â\x03\x92 \x01\x00"
+			           19 01f9                                 #           uint(505)
+			         84                                        #         array(4)
+			           19 025e                                 #           uint(606)
+			           19 02c3                                 #           uint(707)
+			           d8 2a                                   #           tag(42)
+			             49                                    #             bytes(9)
+			               000181e20392200101                  #               "\x00\x01\x81â\x03\x92 \x01\x01"
+			           19 0328                                 #           uint(808)
+			     83                                            #     array(3)
+			       19 012f                                     #       uint(303)
+			       19 0194                                     #       uint(404)
+			       80                                          #       array(0)
+			   f5                                              #   true
+			*/
+			params: ClaimAllocationsParams{
+				Sectors: []SectorAllocationClaims{{
+					Sector:       101,
+					SectorExpiry: 202,
+					Claims: []AllocationClaim{
+						{
+							Client:       303,
+							AllocationId: 404,
+							Data:         cid.MustParse("baga6ea4seaaqa"),
+							Size:         505,
+						},
+						{
+							Client:       606,
+							AllocationId: 707,
+							Data:         cid.MustParse("baga6ea4seaaqc"),
+							Size:         808,
+						},
+					},
+				},
+					{Sector: 303, SectorExpiry: 404, Claims: nil},
+				},
+				AllOrNothing: true,
+			},
+			hex: "828283186518ca828419012f190194d82a49000181e203922001001901f98419025e1902c3d82a49000181e203922001011903288319012f19019480f5",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			req := require.New(t)
+
+			var buf bytes.Buffer
+			req.NoError(tc.params.MarshalCBOR(&buf))
+			req.Equal(tc.hex, hex.EncodeToString(buf.Bytes()))
+			var rt ClaimAllocationsParams
+			req.NoError(rt.UnmarshalCBOR(&buf))
+			req.Equal(tc.params, rt)
+		})
+	}
+}


### PR DESCRIPTION
Since I was touching type changes in https://github.com/filecoin-project/go-state-types/pull/262 I thought I'd do an initial version of something I've proposed doing a more comprehensive form of: cbor encoding and round-trip testing of publicly exported types, which is particularly important for the types we pass through builtin-actors. So for now I'm just starting with  ClaimAllocationsParams, and am following this up with a PR to builtin-actors with identical fixtures.

Ideally we'd expand this, perhaps slowly, to cover the full suite of types that pass through this barrier, and in the process provide fixtures for other implementations to test against as well.

The diagnostic output might be overkill, I can remove that if someone wants to object, I just like being absolutely clear.