### PR TITLE
chore: Update `actors_version_checklist.md` to reference GST-checklist in Lotus

### DIFF
--- a/actors_version_checklist.md
+++ b/actors_version_checklist.md
@@ -1,14 +1,3 @@
 ### Actor version integration checklist
 
-- [ ] Copy `go-state-types/builtin/vX` to `go-state-types/builtin/v(X+1)`
-- [ ] Change all references to `vX` in the new files to `v(X+1)`
-- [ ] Add new network version to `network/version.go`
-- [ ] Add new actors version to `actors/version.go`[^1]
-- [ ] Add the new version to the `gen` step of the makefile`[^2]
-- [ ] run `make gen`
-
-[^1]: 
-    #### Steps:
-    1. **Add a new constant**: Add a new constant in the list of versions. The new constant's name should follow the existing naming convention - i.e., `VersionXX+1  Version = XX+1`, where XX+1 is the new version number.
-    2. **Update `VersionForNetwork` function**: In `version.go`, there's a function called `VersionForNetwork` that accepts a network version and returns the corresponding actor version. Add a new case line for the network version that corresponds to the new actor version you're adding - i.e, `network.Version(XX+1): return Version(XX+1), nil`
-[^2]:  Add `$(GO_BIN) run ./builtin/v(XX+1)/gen/gen.go`
+For detailed steps on integrating a new actor version, please refer to the [Go-State-Types Checklist in the Lotus repository](https://github.com/filecoin-project/lotus/blob/master/documentation/misc/Building_a_network_skeleton.md#go-state-types-checklist).


### PR DESCRIPTION
Closes: #122

Update `actors_version_checklist.md` to reference Go-State-Types Checklist in Lotus repository. This will ensure that the maintenance burden for keeping this checklist up to date is kept low and the documentation remains up-to-date.