### PR TITLE
chore: Update codename for NetworkVersion23

### DIFF
--- a/network/version.go
+++ b/network/version.go
@@ -30,7 +30,7 @@ const (
 	Version20                 // Thunder
 	Version21                 // Watermelon
 	Version22                 // Dragon
-	Version23                 // TBD
+	Version23                 // Waffle
 
 	// VersionMax is the maximum version number
 	VersionMax = Version(math.MaxUint32)


### PR DESCRIPTION
This PR updates the `TBD` codename for NetworkVersion23 in `network/version.go` to reflect that Waffle has been choosen for the codename of NV23: https://metropolis.vote/dashboard/c/6pnapz4axv.

Slack-thread asking for clarification here: https://filecoinproject.slack.com/archives/CEHTVSEG6/p1718632500744349?thread_ts=1717005618.376869&cid=CEHTVSEG6