### PR TITLE
chore: Cleanup invariant errors related to v13 migration

### DIFF
--- a/builtin/v13/check.go
+++ b/builtin/v13/check.go
@@ -267,11 +267,8 @@ func CheckDealStatesAgainstSectors(acc *builtin.MessageAccumulator, minerSummari
 			continue
 		}
 
-		// TODO: If you are reading this error after nv22 (v13 actors), delete this invariant.
-		// It exists to test the v13 migration ONLY.
 		sectorDeal, found := minerSummary.Deals[dealID]
 		if !found {
-			acc.Require(deal.SlashEpoch >= 0, "MIGRATION-ONLY: un-slashed deal %d not referenced in active sectors of miner %v", dealID, deal.Provider)
 			continue
 		}
 
@@ -314,9 +311,9 @@ func CheckDealStatesAgainstSectors(acc *builtin.MessageAccumulator, minerSummari
 
 		for _, dealID := range dealIDs {
 			_, found := minerSummary.Deals[dealID]
-			// TODO: If you are reading this error after nv22 (v13 actors), delete this invariant.
-			// It exists to test the v13 migration ONLY.
-			acc.Require(found, "MIGRATION-ONLY: deal %d not found in miner %v for sector %v", dealID, maddr, sectorID)
+			if !found {
+				continue
+			}
 
 			_, found = marketDealToSector[dealID]
 			acc.Require(!found, "deal %d found in multiple sectors", dealID)


### PR DESCRIPTION
I encountered both these errors when running the invariant-check on mainnet. Deleting these two invariants given that they existed only to test the v13 migration as per the TODO in code comments.

- `"MIGRATION-ONLY: un-slashed deal %d not referenced in active sectors of miner %v", dealID, deal.Provider"`
- `"MIGRATION-ONLY: deal %d not found in miner %v for sector %v", dealID, maddr, sectorID)"`