### PR TITLE
chore: include manifest & proof in `make gen`; add extra proof types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ tidy:
 gen:
 	$(GO_BIN) run ./gen/gen.go
 	$(GO_BIN) run ./manifest/gen/gen.go
+	$(GO_BIN) run ./proof/gen/gen.go
 	$(GO_BIN) run ./builtin/v8/gen/gen.go
 	$(GO_BIN) run ./builtin/v9/gen/gen.go
 	$(GO_BIN) run ./builtin/v10/gen/gen.go

--- a/proof/gen/gen.go
+++ b/proof/gen/gen.go
@@ -10,11 +10,14 @@ func main() {
 	if err := gen.WriteTupleEncodersToFile("./proof/cbor_gen.go", "proof",
 		// actor manifest
 		proof.PoStProof{},
-		proof.ExtendedSectorInfo{},
-		proof.SealVerifyInfo{},
-		proof.WindowPoStVerifyInfo{},
-		proof.WinningPoStVerifyInfo{},
 		proof.SectorInfo{},
+		proof.ExtendedSectorInfo{},
+		proof.WinningPoStVerifyInfo{},
+		proof.WindowPoStVerifyInfo{},
+		proof.SealVerifyInfo{},
+		proof.AggregateSealVerifyInfo{},
+		proof.AggregateSealVerifyProofAndInfos{},
+		proof.ReplicaUpdateInfo{},
 	); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
The `manifest` line in Makefile is included in #283 because it's needed to get past new linting. But `proof` is not included there and I wanted to serialise a couple of the Aggregate types in there for debugging but they don't yet have cbor-gen additions. We don't strictly need these for communication between lotus and actors, but they are handy to have for debugging!