### PR TITLE
fix: market: use expiry-activation for deal weight calculation

### DIFF
--- a/builtin/v13/market/market_state.go
+++ b/builtin/v13/market/market_state.go
@@ -194,7 +194,7 @@ func validateAndComputeDealWeight(proposals *DealArray, dealIDs []abi.DealID, mi
 
 		// Compute deal weight
 		totalDealSpace += uint64(proposal.PieceSize)
-		dealSpaceTime := DealWeight(proposal)
+		dealSpaceTime := DealWeight(proposal, sectorExpiry, sectorActivation)
 		if proposal.VerifiedDeal {
 			totalVerifiedSpaceTime = big.Add(totalVerifiedSpaceTime, dealSpaceTime)
 		} else {

--- a/builtin/v13/market/policy.go
+++ b/builtin/v13/market/policy.go
@@ -55,8 +55,8 @@ func DealClientCollateralBounds(_ abi.PaddedPieceSize, _ abi.ChainEpoch) (min ab
 }
 
 // Computes the weight for a deal proposal, which is a function of its size and duration.
-func DealWeight(proposal *DealProposal) abi.DealWeight {
-	dealDuration := big.NewInt(int64(proposal.Duration()))
+func DealWeight(proposal *DealProposal, sectorExpiry abi.ChainEpoch, sectorActivation abi.ChainEpoch) abi.DealWeight {
+	dealDuration := big.NewInt(int64(sectorExpiry - sectorActivation))
 	dealSize := big.NewIntUnsigned(uint64(proposal.PieceSize))
 	dealSpaceTime := big.Mul(dealDuration, dealSize)
 	return dealSpaceTime

--- a/builtin/v14/market/market_state.go
+++ b/builtin/v14/market/market_state.go
@@ -194,7 +194,7 @@ func validateAndComputeDealWeight(proposals *DealArray, dealIDs []abi.DealID, mi
 
 		// Compute deal weight
 		totalDealSpace += uint64(proposal.PieceSize)
-		dealSpaceTime := DealWeight(proposal)
+		dealSpaceTime := DealWeight(proposal, sectorExpiry, sectorActivation)
 		if proposal.VerifiedDeal {
 			totalVerifiedSpaceTime = big.Add(totalVerifiedSpaceTime, dealSpaceTime)
 		} else {

--- a/builtin/v14/market/policy.go
+++ b/builtin/v14/market/policy.go
@@ -55,8 +55,8 @@ func DealClientCollateralBounds(_ abi.PaddedPieceSize, _ abi.ChainEpoch) (min ab
 }
 
 // Computes the weight for a deal proposal, which is a function of its size and duration.
-func DealWeight(proposal *DealProposal) abi.DealWeight {
-	dealDuration := big.NewInt(int64(proposal.Duration()))
+func DealWeight(proposal *DealProposal, sectorExpiry abi.ChainEpoch, sectorActivation abi.ChainEpoch) abi.DealWeight {
+	dealDuration := big.NewInt(int64(sectorExpiry - sectorActivation))
 	dealSize := big.NewIntUnsigned(uint64(proposal.PieceSize))
 	dealSpaceTime := big.Mul(dealDuration, dealSize)
 	return dealSpaceTime


### PR DESCRIPTION
Ref: https://github.com/filecoin-project/go-state-types/pull/237

This is the same as #237 but on top of master and with v14 included and v12 excluded.

It's a 👍 from me and @magik6k endorsed this on slack and it _possibly_ (but maybe not) addresses a live issue being experienced by lotus-miner @ https://github.com/filecoin-project/lotus/issues/12014

This apparently should have been done with the introduction of allocation term-min term-max.

As per my comment in #239 on the scope of this and what it touches:

> In actors we calculate duration the same way: https://github.com/filecoin-project/builtin-actors/blob/8d957d2901c0f2044417c268f0511324f591cb92/actors/miner/src/lib.rs#L5522-L5534
>
> This code gets used in lotus for StateMinerPreCommitDepositForPower here: https://github.com/filecoin-project/lotus/blob/21abfc69fb552b92fa3ce223e863f1d582dec237/node/impl/full/state.go#L1463-L1468

