### PR TITLE
fix(migration): improve job progress logging in MigrateStateTree

### DIFF
--- a/builtin/v9/migration/top.go
+++ b/builtin/v9/migration/top.go
@@ -397,12 +397,11 @@ func MigrateStateTree(ctx context.Context, store cbor.IpldStore, newManifestCID 
 				case <-time.After(cfg.ProgressLogPeriod):
 					jobsNow := jobCount // Snapshot values to avoid incorrect-looking arithmetic if they change.
 					doneNow := doneCount
+					pendingNow := jobsNow - doneNow
 					elapsed := time.Since(startTime)
 					rate := float64(doneNow) / elapsed.Seconds()
-					percentComplete := float64(doneNow) / float64(jobsNow) * 100
-
-					log.Log(rt.INFO, "Performing migration: %d of %d jobs complete (%.1f%%, %.0f/s)",
-						doneNow, jobsNow, percentComplete, rate)
+					log.Log(rt.INFO, "%d jobs created, %d done, %d pending after %v (%.0f/s)",
+						jobsNow, doneNow, pendingNow, elapsed, rate)
 				case <-workersFinished:
 					return
 				case <-ctx.Done():

--- a/builtin/v9/migration/top.go
+++ b/builtin/v9/migration/top.go
@@ -395,8 +395,8 @@ func MigrateStateTree(ctx context.Context, store cbor.IpldStore, newManifestCID 
 			for {
 				select {
 				case <-time.After(cfg.ProgressLogPeriod):
-					jobsNow := atomic.LoadUint32(&jobCount) // Snapshot values to avoid incorrect-looking arithmetic if they change.
-					doneNow := atomic.LoadUint32(&doneCount)
+					jobsNow := jobCount // Snapshot values to avoid incorrect-looking arithmetic if they change.
+					doneNow := doneCount
 					elapsed := time.Since(startTime)
 					rate := float64(doneNow) / elapsed.Seconds()
 					percentComplete := float64(doneNow) / float64(jobsNow) * 100

--- a/migration/runner.go
+++ b/migration/runner.go
@@ -110,7 +110,7 @@ func RunMigration(ctx context.Context, cfg Config, cache MigrationCache, store c
 					rate := float64(doneNow) / elapsed.Seconds()
 
 					log.Log(rt.INFO, "Performing migration: %d of %d jobs processed (%.0f/s) [%v elapsed]",
-						doneNow, jobsNow, rate, elapsed.Round(100*time.Millisecond))
+						doneNow, jobsNow, rate, elapsed.Round(time.Second))
 				case <-workersFinished:
 					return
 				case <-ctx.Done():

--- a/migration/runner.go
+++ b/migration/runner.go
@@ -2,7 +2,6 @@ package migration
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -112,12 +111,8 @@ func RunMigration(ctx context.Context, cfg Config, cache MigrationCache, store c
 					elapsed := time.Since(startTime)
 					rate := float64(doneNow) / elapsed.Seconds()
 
-					jobsStr := fmt.Sprintf("%d", jobsNow)
-					doneStr := fmt.Sprintf("%d", doneNow)
-					rateStr := fmt.Sprintf("%.0f", rate)
-
-					log.Log(rt.INFO, "Performing migration: %s of %s jobs processed (%s/s) [%v elapsed]",
-						doneStr, jobsStr, rateStr, elapsed.Round(time.Second))
+					log.Log(rt.INFO, "Performing migration: %d of %d jobs processed (%.0f/s) [%v elapsed]",
+						doneNow, jobsNow, rate, elapsed.Round(time.Second))
 				case <-workersFinished:
 					return
 				case <-ctx.Done():


### PR DESCRIPTION
reference to https://github.com/filecoin-project/lotus/pull/12732
This pull request includes an update to the logging format in the `MigrateStateTree` function to improve clarity during the migration process.

Logging improvements:

* [`builtin/v9/migration/top.go`](diffhunk://#diff-0f71e4e5376421454dd6e1792714840e621766fb31e279de1749157bf59a8bd3L400-R405): Changed the log message to include the percentage of jobs completed and rephrased the message for better readability.