### PR TITLE
fip-0100: update the vesting funds types to the new layout

### DIFF
--- a/builtin/v10/miner/invariants.go
+++ b/builtin/v10/miner/invariants.go
@@ -757,7 +757,7 @@ func CheckMinerBalances(st *State, store adt.Store, balance abi.TokenAmount, acc
 		acc.Addf("error loading vesting funds: %v", err)
 	} else {
 		quant := st.QuantSpecEveryDeadline()
-		for _, entry := range funds.Funds {
+		for _, entry := range funds {
 			acc.Require(entry.Amount.GreaterThan(big.Zero()), "non-positive amount in miner vesting table entry %v", entry)
 			vestingSum = big.Add(vestingSum, entry.Amount)
 

--- a/builtin/v10/miner/miner_state.go
+++ b/builtin/v10/miner/miner_state.go
@@ -259,13 +259,13 @@ func (st *State) SaveDeadlines(store adt.Store, deadlines *Deadlines) error {
 }
 
 // LoadVestingFunds loads the vesting funds table from the store
-func (st *State) LoadVestingFunds(store adt.Store) (*VestingFunds, error) {
+func (st *State) LoadVestingFunds(store adt.Store) ([]VestingFund, error) {
 	var funds VestingFunds
 	if err := store.Get(store.Context(), st.VestingFunds, &funds); err != nil {
 		return nil, xerrors.Errorf("failed to load vesting funds (%s): %w", st.VestingFunds, err)
 	}
 
-	return &funds, nil
+	return funds.Funds, nil
 }
 
 // CheckVestedFunds returns the amount of vested funds that have vested before the provided epoch.
@@ -277,8 +277,8 @@ func (st *State) CheckVestedFunds(store adt.Store, currEpoch abi.ChainEpoch) (ab
 
 	amountVested := abi.NewTokenAmount(0)
 
-	for i := range vestingFunds.Funds {
-		vf := vestingFunds.Funds[i]
+	for i := range vestingFunds {
+		vf := vestingFunds[i]
 		epoch := vf.Epoch
 		amount := vf.Amount
 

--- a/builtin/v11/miner/invariants.go
+++ b/builtin/v11/miner/invariants.go
@@ -757,7 +757,7 @@ func CheckMinerBalances(st *State, store adt.Store, balance abi.TokenAmount, acc
 		acc.Addf("error loading vesting funds: %v", err)
 	} else {
 		quant := st.QuantSpecEveryDeadline()
-		for _, entry := range funds.Funds {
+		for _, entry := range funds {
 			acc.Require(entry.Amount.GreaterThan(big.Zero()), "non-positive amount in miner vesting table entry %v", entry)
 			vestingSum = big.Add(vestingSum, entry.Amount)
 

--- a/builtin/v11/miner/miner_state.go
+++ b/builtin/v11/miner/miner_state.go
@@ -259,13 +259,13 @@ func (st *State) SaveDeadlines(store adt.Store, deadlines *Deadlines) error {
 }
 
 // LoadVestingFunds loads the vesting funds table from the store
-func (st *State) LoadVestingFunds(store adt.Store) (*VestingFunds, error) {
+func (st *State) LoadVestingFunds(store adt.Store) ([]VestingFund, error) {
 	var funds VestingFunds
 	if err := store.Get(store.Context(), st.VestingFunds, &funds); err != nil {
 		return nil, xerrors.Errorf("failed to load vesting funds (%s): %w", st.VestingFunds, err)
 	}
 
-	return &funds, nil
+	return funds.Funds, nil
 }
 
 // CheckVestedFunds returns the amount of vested funds that have vested before the provided epoch.
@@ -277,8 +277,8 @@ func (st *State) CheckVestedFunds(store adt.Store, currEpoch abi.ChainEpoch) (ab
 
 	amountVested := abi.NewTokenAmount(0)
 
-	for i := range vestingFunds.Funds {
-		vf := vestingFunds.Funds[i]
+	for i := range vestingFunds {
+		vf := vestingFunds[i]
 		epoch := vf.Epoch
 		amount := vf.Amount
 

--- a/builtin/v12/miner/invariants.go
+++ b/builtin/v12/miner/invariants.go
@@ -759,7 +759,7 @@ func CheckMinerBalances(st *State, store adt.Store, balance abi.TokenAmount, acc
 		acc.Addf("error loading vesting funds: %v", err)
 	} else {
 		quant := st.QuantSpecEveryDeadline()
-		for _, entry := range funds.Funds {
+		for _, entry := range funds {
 			acc.Require(entry.Amount.GreaterThan(big.Zero()), "non-positive amount in miner vesting table entry %v", entry)
 			vestingSum = big.Add(vestingSum, entry.Amount)
 

--- a/builtin/v12/miner/miner_state.go
+++ b/builtin/v12/miner/miner_state.go
@@ -266,13 +266,13 @@ func (st *State) SaveDeadlines(store adt.Store, deadlines *Deadlines) error {
 }
 
 // LoadVestingFunds loads the vesting funds table from the store
-func (st *State) LoadVestingFunds(store adt.Store) (*VestingFunds, error) {
+func (st *State) LoadVestingFunds(store adt.Store) ([]VestingFund, error) {
 	var funds VestingFunds
 	if err := store.Get(store.Context(), st.VestingFunds, &funds); err != nil {
 		return nil, xerrors.Errorf("failed to load vesting funds (%s): %w", st.VestingFunds, err)
 	}
 
-	return &funds, nil
+	return funds.Funds, nil
 }
 
 // CheckVestedFunds returns the amount of vested funds that have vested before the provided epoch.
@@ -284,8 +284,8 @@ func (st *State) CheckVestedFunds(store adt.Store, currEpoch abi.ChainEpoch) (ab
 
 	amountVested := abi.NewTokenAmount(0)
 
-	for i := range vestingFunds.Funds {
-		vf := vestingFunds.Funds[i]
+	for i := range vestingFunds {
+		vf := vestingFunds[i]
 		epoch := vf.Epoch
 		amount := vf.Amount
 

--- a/builtin/v13/miner/invariants.go
+++ b/builtin/v13/miner/invariants.go
@@ -755,7 +755,7 @@ func CheckMinerBalances(st *State, store adt.Store, balance abi.TokenAmount, acc
 		acc.Addf("error loading vesting funds: %v", err)
 	} else {
 		quant := st.QuantSpecEveryDeadline()
-		for _, entry := range funds.Funds {
+		for _, entry := range funds {
 			acc.Require(entry.Amount.GreaterThan(big.Zero()), "non-positive amount in miner vesting table entry %v", entry)
 			vestingSum = big.Add(vestingSum, entry.Amount)
 

--- a/builtin/v13/miner/miner_state.go
+++ b/builtin/v13/miner/miner_state.go
@@ -266,13 +266,13 @@ func (st *State) SaveDeadlines(store adt.Store, deadlines *Deadlines) error {
 }
 
 // LoadVestingFunds loads the vesting funds table from the store
-func (st *State) LoadVestingFunds(store adt.Store) (*VestingFunds, error) {
+func (st *State) LoadVestingFunds(store adt.Store) ([]VestingFund, error) {
 	var funds VestingFunds
 	if err := store.Get(store.Context(), st.VestingFunds, &funds); err != nil {
 		return nil, xerrors.Errorf("failed to load vesting funds (%s): %w", st.VestingFunds, err)
 	}
 
-	return &funds, nil
+	return funds.Funds, nil
 }
 
 // CheckVestedFunds returns the amount of vested funds that have vested before the provided epoch.
@@ -284,8 +284,8 @@ func (st *State) CheckVestedFunds(store adt.Store, currEpoch abi.ChainEpoch) (ab
 
 	amountVested := abi.NewTokenAmount(0)
 
-	for i := range vestingFunds.Funds {
-		vf := vestingFunds.Funds[i]
+	for i := range vestingFunds {
+		vf := vestingFunds[i]
 		epoch := vf.Epoch
 		amount := vf.Amount
 

--- a/builtin/v14/miner/invariants.go
+++ b/builtin/v14/miner/invariants.go
@@ -755,7 +755,7 @@ func CheckMinerBalances(st *State, store adt.Store, balance abi.TokenAmount, acc
 		acc.Addf("error loading vesting funds: %v", err)
 	} else {
 		quant := st.QuantSpecEveryDeadline()
-		for _, entry := range funds.Funds {
+		for _, entry := range funds {
 			acc.Require(entry.Amount.GreaterThan(big.Zero()), "non-positive amount in miner vesting table entry %v", entry)
 			vestingSum = big.Add(vestingSum, entry.Amount)
 

--- a/builtin/v14/miner/miner_state.go
+++ b/builtin/v14/miner/miner_state.go
@@ -266,13 +266,13 @@ func (st *State) SaveDeadlines(store adt.Store, deadlines *Deadlines) error {
 }
 
 // LoadVestingFunds loads the vesting funds table from the store
-func (st *State) LoadVestingFunds(store adt.Store) (*VestingFunds, error) {
+func (st *State) LoadVestingFunds(store adt.Store) ([]VestingFund, error) {
 	var funds VestingFunds
 	if err := store.Get(store.Context(), st.VestingFunds, &funds); err != nil {
 		return nil, xerrors.Errorf("failed to load vesting funds (%s): %w", st.VestingFunds, err)
 	}
 
-	return &funds, nil
+	return funds.Funds, nil
 }
 
 // CheckVestedFunds returns the amount of vested funds that have vested before the provided epoch.
@@ -284,8 +284,8 @@ func (st *State) CheckVestedFunds(store adt.Store, currEpoch abi.ChainEpoch) (ab
 
 	amountVested := abi.NewTokenAmount(0)
 
-	for i := range vestingFunds.Funds {
-		vf := vestingFunds.Funds[i]
+	for i := range vestingFunds {
+		vf := vestingFunds[i]
 		epoch := vf.Epoch
 		amount := vf.Amount
 

--- a/builtin/v15/miner/invariants.go
+++ b/builtin/v15/miner/invariants.go
@@ -755,7 +755,7 @@ func CheckMinerBalances(st *State, store adt.Store, balance abi.TokenAmount, acc
 		acc.Addf("error loading vesting funds: %v", err)
 	} else {
 		quant := st.QuantSpecEveryDeadline()
-		for _, entry := range funds.Funds {
+		for _, entry := range funds {
 			acc.Require(entry.Amount.GreaterThan(big.Zero()), "non-positive amount in miner vesting table entry %v", entry)
 			vestingSum = big.Add(vestingSum, entry.Amount)
 

--- a/builtin/v15/miner/miner_state.go
+++ b/builtin/v15/miner/miner_state.go
@@ -266,13 +266,13 @@ func (st *State) SaveDeadlines(store adt.Store, deadlines *Deadlines) error {
 }
 
 // LoadVestingFunds loads the vesting funds table from the store
-func (st *State) LoadVestingFunds(store adt.Store) (*VestingFunds, error) {
+func (st *State) LoadVestingFunds(store adt.Store) ([]VestingFund, error) {
 	var funds VestingFunds
 	if err := store.Get(store.Context(), st.VestingFunds, &funds); err != nil {
 		return nil, xerrors.Errorf("failed to load vesting funds (%s): %w", st.VestingFunds, err)
 	}
 
-	return &funds, nil
+	return funds.Funds, nil
 }
 
 // CheckVestedFunds returns the amount of vested funds that have vested before the provided epoch.
@@ -284,8 +284,8 @@ func (st *State) CheckVestedFunds(store adt.Store, currEpoch abi.ChainEpoch) (ab
 
 	amountVested := abi.NewTokenAmount(0)
 
-	for i := range vestingFunds.Funds {
-		vf := vestingFunds.Funds[i]
+	for i := range vestingFunds {
+		vf := vestingFunds[i]
 		epoch := vf.Epoch
 		amount := vf.Amount
 

--- a/builtin/v16/gen/gen.go
+++ b/builtin/v16/gen/gen.go
@@ -154,6 +154,7 @@ func main() {
 		miner.SectorPreCommitInfo{},
 		miner.SectorOnChainInfo{},
 		miner.WorkerKeyChange{},
+		miner.VestingFundsTail{},
 		miner.VestingFunds{},
 		miner.VestingFund{},
 		miner.WindowedPoSt{},

--- a/builtin/v16/miner/invariants.go
+++ b/builtin/v16/miner/invariants.go
@@ -755,7 +755,7 @@ func CheckMinerBalances(st *State, store adt.Store, balance abi.TokenAmount, acc
 		acc.Addf("error loading vesting funds: %v", err)
 	} else {
 		quant := st.QuantSpecEveryDeadline()
-		for _, entry := range funds.Funds {
+		for _, entry := range funds {
 			acc.Require(entry.Amount.GreaterThan(big.Zero()), "non-positive amount in miner vesting table entry %v", entry)
 			vestingSum = big.Add(vestingSum, entry.Amount)
 

--- a/builtin/v16/miner/miner_types.go
+++ b/builtin/v16/miner/miner_types.go
@@ -318,23 +318,23 @@ func (sa Sectors) Get(sectorNumber abi.SectorNumber) (info *SectorOnChainInfo, f
 }
 
 // VestingFunds represents the vesting table state for the miner.
-// It is a slice of (VestingEpoch, VestingAmount).
-// The slice will always be sorted by the VestingEpoch.
 type VestingFunds struct {
-	Funds []VestingFund
+	// The next batch of vesting funds.
+	Head VestingFund
+	// The rest of the vesting funds.
+	Tail cid.Cid // VestingFundsTail
+}
+
+// VestingFundTail represents the tail of a vesting funds table in the miner. It's an array of
+// (VestingEpoch, VestingAmount) tuples. The slice will always be sorted by the VestingEpoch.
+type VestingFundsTail struct {
+	Funds []VestingFund `cborgen:"transparent"`
 }
 
 // VestingFund represents miner funds that will vest at the given epoch.
 type VestingFund struct {
 	Epoch  abi.ChainEpoch
 	Amount abi.TokenAmount
-}
-
-// ConstructVestingFunds constructs empty VestingFunds state.
-func ConstructVestingFunds() *VestingFunds {
-	v := new(VestingFunds)
-	v.Funds = nil
-	return v
 }
 
 type DeferredCronEventParams struct {

--- a/builtin/v16/miner/unmarshall_test.go
+++ b/builtin/v16/miner/unmarshall_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/filecoin-project/go-state-types/big"
 )
 
-func TestCborVestingFunds(t *testing.T) {
-	var vf = VestingFunds{
+func TestCborVestingFundsTail(t *testing.T) {
+	var vf = VestingFundsTail{
 		Funds: []VestingFund{
 			{
 				Epoch:  1,
@@ -27,12 +27,12 @@ func TestCborVestingFunds(t *testing.T) {
 	err := vf.MarshalCBOR(buf)
 	require.NoError(t, err)
 
-	// Value taken from builtin-actors test.
-	b := []byte{129, 130, 130, 1, 66, 0, 3, 130, 2, 66, 0, 4}
+	// This encodes as a bare CBOR list (no wrapping struct).
+	b := []byte{130, 130, 1, 66, 0, 3, 130, 2, 66, 0, 4}
 
 	require.Equal(t, b, buf.Bytes())
 
-	var vf2 VestingFunds
+	var vf2 VestingFundsTail
 	err = vf2.UnmarshalCBOR(bytes.NewReader(b))
 	require.NoError(t, err)
 	require.Equal(t, abi.ChainEpoch(1), vf2.Funds[0].Epoch)

--- a/builtin/v8/miner/invariants.go
+++ b/builtin/v8/miner/invariants.go
@@ -750,7 +750,7 @@ func CheckMinerBalances(st *State, store adt.Store, balance abi.TokenAmount, acc
 		acc.Addf("error loading vesting funds: %v", err)
 	} else {
 		quant := st.QuantSpecEveryDeadline()
-		for _, entry := range funds.Funds {
+		for _, entry := range funds {
 			acc.Require(entry.Amount.GreaterThan(big.Zero()), "non-positive amount in miner vesting table entry %v", entry)
 			vestingSum = big.Add(vestingSum, entry.Amount)
 

--- a/builtin/v8/miner/miner_state.go
+++ b/builtin/v8/miner/miner_state.go
@@ -239,13 +239,13 @@ func (st *State) SaveDeadlines(store adt.Store, deadlines *Deadlines) error {
 }
 
 // LoadVestingFunds loads the vesting funds table from the store
-func (st *State) LoadVestingFunds(store adt.Store) (*VestingFunds, error) {
+func (st *State) LoadVestingFunds(store adt.Store) ([]VestingFund, error) {
 	var funds VestingFunds
 	if err := store.Get(store.Context(), st.VestingFunds, &funds); err != nil {
 		return nil, xerrors.Errorf("failed to load vesting funds (%s): %w", st.VestingFunds, err)
 	}
 
-	return &funds, nil
+	return funds.Funds, nil
 }
 
 // CheckVestedFunds returns the amount of vested funds that have vested before the provided epoch.
@@ -257,8 +257,8 @@ func (st *State) CheckVestedFunds(store adt.Store, currEpoch abi.ChainEpoch) (ab
 
 	amountVested := abi.NewTokenAmount(0)
 
-	for i := range vestingFunds.Funds {
-		vf := vestingFunds.Funds[i]
+	for i := range vestingFunds {
+		vf := vestingFunds[i]
 		epoch := vf.Epoch
 		amount := vf.Amount
 

--- a/builtin/v9/miner/invariants.go
+++ b/builtin/v9/miner/invariants.go
@@ -757,7 +757,7 @@ func CheckMinerBalances(st *State, store adt.Store, balance abi.TokenAmount, acc
 		acc.Addf("error loading vesting funds: %v", err)
 	} else {
 		quant := st.QuantSpecEveryDeadline()
-		for _, entry := range funds.Funds {
+		for _, entry := range funds {
 			acc.Require(entry.Amount.GreaterThan(big.Zero()), "non-positive amount in miner vesting table entry %v", entry)
 			vestingSum = big.Add(vestingSum, entry.Amount)
 

--- a/builtin/v9/miner/miner_state.go
+++ b/builtin/v9/miner/miner_state.go
@@ -259,13 +259,13 @@ func (st *State) SaveDeadlines(store adt.Store, deadlines *Deadlines) error {
 }
 
 // LoadVestingFunds loads the vesting funds table from the store
-func (st *State) LoadVestingFunds(store adt.Store) (*VestingFunds, error) {
+func (st *State) LoadVestingFunds(store adt.Store) ([]VestingFund, error) {
 	var funds VestingFunds
 	if err := store.Get(store.Context(), st.VestingFunds, &funds); err != nil {
 		return nil, xerrors.Errorf("failed to load vesting funds (%s): %w", st.VestingFunds, err)
 	}
 
-	return &funds, nil
+	return funds.Funds, nil
 }
 
 // CheckVestedFunds returns the amount of vested funds that have vested before the provided epoch.
@@ -277,8 +277,8 @@ func (st *State) CheckVestedFunds(store adt.Store, currEpoch abi.ChainEpoch) (ab
 
 	amountVested := abi.NewTokenAmount(0)
 
-	for i := range vestingFunds.Funds {
-		vf := vestingFunds.Funds[i]
+	for i := range vestingFunds {
+		vf := vestingFunds[i]
 		epoch := vf.Epoch
 		amount := vf.Amount
 


### PR DESCRIPTION
I've also changed the `LoadVestingFunds` to return a `[]VestingFund` so we can abstract across the different underlying representations.

fixes #350 