### PR TITLE
fix(miner): adjust SectorOnChainInfo to FIP-0098 changes

### DIFF
--- a/big/int.go
+++ b/big/int.go
@@ -285,6 +285,11 @@ func (bi *Int) UnmarshalBinary(buf []byte) error {
 }
 
 func (bi *Int) MarshalCBOR(w io.Writer) error {
+	if bi == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+
 	if bi.Int == nil {
 		zero := Zero()
 		return zero.MarshalCBOR(w)

--- a/builtin/v16/miner/cbor_gen.go
+++ b/builtin/v16/miner/cbor_gen.go
@@ -10,6 +10,7 @@ import (
 
 	address "github.com/filecoin-project/go-address"
 	abi "github.com/filecoin-project/go-state-types/abi"
+	big "github.com/filecoin-project/go-state-types/big"
 	verifreg "github.com/filecoin-project/go-state-types/builtin/v16/verifreg"
 	proof "github.com/filecoin-project/go-state-types/proof"
 	cid "github.com/ipfs/go-cid"
@@ -2289,8 +2290,18 @@ func (t *SectorOnChainInfo) UnmarshalCBOR(r io.Reader) (err error) {
 
 	{
 
-		if err := t.ExpectedDayReward.UnmarshalCBOR(cr); err != nil {
-			return xerrors.Errorf("unmarshaling t.ExpectedDayReward: %w", err)
+		b, err := cr.ReadByte()
+		if err != nil {
+			return err
+		}
+		if b != cbg.CborNull[0] {
+			if err := cr.UnreadByte(); err != nil {
+				return err
+			}
+			t.ExpectedDayReward = new(big.Int)
+			if err := t.ExpectedDayReward.UnmarshalCBOR(cr); err != nil {
+				return xerrors.Errorf("unmarshaling t.ExpectedDayReward pointer: %w", err)
+			}
 		}
 
 	}
@@ -2298,8 +2309,18 @@ func (t *SectorOnChainInfo) UnmarshalCBOR(r io.Reader) (err error) {
 
 	{
 
-		if err := t.ExpectedStoragePledge.UnmarshalCBOR(cr); err != nil {
-			return xerrors.Errorf("unmarshaling t.ExpectedStoragePledge: %w", err)
+		b, err := cr.ReadByte()
+		if err != nil {
+			return err
+		}
+		if b != cbg.CborNull[0] {
+			if err := cr.UnreadByte(); err != nil {
+				return err
+			}
+			t.ExpectedStoragePledge = new(big.Int)
+			if err := t.ExpectedStoragePledge.UnmarshalCBOR(cr); err != nil {
+				return xerrors.Errorf("unmarshaling t.ExpectedStoragePledge pointer: %w", err)
+			}
 		}
 
 	}
@@ -2332,8 +2353,18 @@ func (t *SectorOnChainInfo) UnmarshalCBOR(r io.Reader) (err error) {
 
 	{
 
-		if err := t.ReplacedDayReward.UnmarshalCBOR(cr); err != nil {
-			return xerrors.Errorf("unmarshaling t.ReplacedDayReward: %w", err)
+		b, err := cr.ReadByte()
+		if err != nil {
+			return err
+		}
+		if b != cbg.CborNull[0] {
+			if err := cr.UnreadByte(); err != nil {
+				return err
+			}
+			t.ReplacedDayReward = new(big.Int)
+			if err := t.ReplacedDayReward.UnmarshalCBOR(cr); err != nil {
+				return xerrors.Errorf("unmarshaling t.ReplacedDayReward pointer: %w", err)
+			}
 		}
 
 	}

--- a/builtin/v16/miner/miner_state.go
+++ b/builtin/v16/miner/miner_state.go
@@ -175,10 +175,10 @@ type SectorOnChainInfo struct {
 	DealWeight            abi.DealWeight         // Integral of active deals over sector lifetime
 	VerifiedDealWeight    abi.DealWeight         // Integral of active verified deals over sector lifetime
 	InitialPledge         abi.TokenAmount        // Pledge collected to commit this sector
-	ExpectedDayReward     abi.TokenAmount        // Expected one day projection of reward for sector computed at activation time
-	ExpectedStoragePledge abi.TokenAmount        // Expected twenty day projection of reward for sector computed at activation time
+	ExpectedDayReward     *abi.TokenAmount       // Expected one day projection of reward for sector computed at activation time
+	ExpectedStoragePledge *abi.TokenAmount       // Expected twenty day projection of reward for sector computed at activation time
 	PowerBaseEpoch        abi.ChainEpoch         // Epoch at which this sector's power was most recently updated
-	ReplacedDayReward     abi.TokenAmount        // Day reward of this sector before its power was most recently updated
+	ReplacedDayReward     *abi.TokenAmount       // Day reward of this sector before its power was most recently updated
 	SectorKeyCID          *cid.Cid               // The original SealedSectorCID, only gets set on the first ReplicaUpdate
 	Flags                 SectorOnChainInfoFlags // Additional flags
 	// The total fee payable per day for this sector. The value of this field is set at the time of

--- a/builtin/v16/miner/miner_types_test.go
+++ b/builtin/v16/miner/miner_types_test.go
@@ -115,15 +115,15 @@ func TestSectorOnChainInfo(t *testing.T) {
 				DealWeight:            zero,
 				VerifiedDealWeight:    zero,
 				InitialPledge:         zero,
-				ExpectedDayReward:     zero,
-				ExpectedStoragePledge: zero,
-				ReplacedDayReward:     zero,
+				ExpectedDayReward:     nil,
+				ExpectedStoragePledge: nil,
+				ReplacedDayReward:     nil,
 				DailyFee:              zero,
 			},
-			// [0,-1,{"/":"baeaaaaa"},[],0,0,[],[],[],[],[],0,[],null,0,[]]
-			readHex: "900020d82a45000100000080000040404040400040f60040",
+			// [0,-1,{"/":"baeaaaaa"},[],0,0,[],[],[],null,null,0,null,null,0,[]]
+			readHex: "900020d82a450001000000800000404040f6f600f6f60040",
 			// same on write as read
-			writeHex: "900020d82a45000100000080000040404040400040f60040",
+			writeHex: "900020d82a450001000000800000404040f6f600f6f60040",
 		},
 		{
 			sector: SectorOnChainInfo{
@@ -136,18 +136,18 @@ func TestSectorOnChainInfo(t *testing.T) {
 				DealWeight:            big.NewInt(4),
 				VerifiedDealWeight:    big.NewInt(5),
 				InitialPledge:         filWhole(6),
-				ExpectedDayReward:     filWhole(7),
-				ExpectedStoragePledge: filWhole(8),
+				ExpectedDayReward:     nil,
+				ExpectedStoragePledge: nil,
 				PowerBaseEpoch:        9,
-				ReplacedDayReward:     filWhole(10),
+				ReplacedDayReward:     nil,
 				SectorKeyCID:          nil,
 				Flags:                 0,
 				DailyFee:              filWhole(11),
 			},
-			// '[1,8,{"/":"bagboea4seaaqa"},[],2,3,[AAQ],[AAU],[AFNESDXsWAAA],[AGEk/umTvAAA],[AG8FtZ07IAAA],9,[AIrHIwSJ6AAA],null,0,[AJin2bgxTAAA]]'
-			readHex: "900108d82a49000182e20392200100800203420004420005490053444835ec58000049006124fee993bc000049006f05b59d3b2000000949008ac7230489e80000f600490098a7d9b8314c0000",
+			// '[1,8,{"/":"bagboea4seaaqa"},[],2,3,[AAQ],[AAU],[AFNESDXsWAAA],null,null,9,null,null,0,[AJin2bgxTAAA]]'
+			readHex: "900108d82a49000182e20392200100800203420004420005490053444835ec580000f6f609f6f600490098a7d9b8314c0000",
 			// same on write as read
-			writeHex: "900108d82a49000182e20392200100800203420004420005490053444835ec58000049006124fee993bc000049006f05b59d3b2000000949008ac7230489e80000f600490098a7d9b8314c0000",
+			writeHex: "900108d82a49000182e20392200100800203420004420005490053444835ec580000f6f609f6f600490098a7d9b8314c0000",
 		},
 		{
 			sector: SectorOnChainInfo{
@@ -160,18 +160,18 @@ func TestSectorOnChainInfo(t *testing.T) {
 				DealWeight:            big.NewInt(4),
 				VerifiedDealWeight:    big.NewInt(5),
 				InitialPledge:         filWhole(6),
-				ExpectedDayReward:     filWhole(7),
-				ExpectedStoragePledge: filWhole(8),
+				ExpectedDayReward:     nil,
+				ExpectedStoragePledge: nil,
 				PowerBaseEpoch:        9,
-				ReplacedDayReward:     filWhole(10),
+				ReplacedDayReward:     nil,
 				SectorKeyCID:          &sectorKey,
 				Flags:                 SIMPLE_QA_POWER,
 				DailyFee:              filWhole(11),
 			},
-			// [1,8,{"/":"bagboea4seaaqa"},[],2,3,[AAQ],[AAU],[AFNESDXsWAAA],[AGEk/umTvAAA],[AG8FtZ07IAAA],9,[AIrHIwSJ6AAA],{"/":"baga6ea4seaaqc"},1,[AJin2bgxTAAA]]
-			readHex: "900108d82a49000182e20392200100800203420004420005490053444835ec58000049006124fee993bc000049006f05b59d3b2000000949008ac7230489e80000d82a49000181e2039220010101490098a7d9b8314c0000",
+			// [1,8,{"/":"bagboea4seaaqa"},[],2,3,[AAQ],[AAU],[AFNESDXsWAAA],null,null,9,null,{"/":"baga6ea4seaaqc"},1,[AJin2bgxTAAA]]
+			readHex: "900108d82a49000182e20392200100800203420004420005490053444835ec580000f6f609f6d82a49000181e2039220010101490098a7d9b8314c0000",
 			// same on write as read
-			writeHex: "900108d82a49000182e20392200100800203420004420005490053444835ec58000049006124fee993bc000049006f05b59d3b2000000949008ac7230489e80000d82a49000181e2039220010101490098a7d9b8314c0000",
+			writeHex: "900108d82a49000182e20392200100800203420004420005490053444835ec580000f6f609f6d82a49000181e2039220010101490098a7d9b8314c0000",
 		},
 		{
 			// old format stored on chain but materialised as the new format with a default value at the end
@@ -185,19 +185,19 @@ func TestSectorOnChainInfo(t *testing.T) {
 				DealWeight:            big.NewInt(4),
 				VerifiedDealWeight:    big.NewInt(5),
 				InitialPledge:         filWhole(6),
-				ExpectedDayReward:     filWhole(7),
-				ExpectedStoragePledge: filWhole(8),
+				ExpectedDayReward:     nil,
+				ExpectedStoragePledge: nil,
 				PowerBaseEpoch:        9,
-				ReplacedDayReward:     filWhole(10),
+				ReplacedDayReward:     nil,
 				SectorKeyCID:          nil,
 				Flags:                 SIMPLE_QA_POWER,
 				DailyFee:              big.Int{}, // default, not present in the binary
 			},
-			// [1,9,{"/":"bagboea4seaaqa"},[],2,3,[AAQ],[AAU],[AFNESDXsWAAA],[AGEk/umTvAAA],[AG8FtZ07IAAA],9,[AIrHIwSJ6AAA],null,1]
-			readHex: "8f0109d82a49000182e20392200100800203420004420005490053444835ec58000049006124fee993bc000049006f05b59d3b2000000949008ac7230489e80000f601",
+			// [1,9,{"/":"bagboea4seaaqa"},[],2,3,[AAQ],[AAU],[AFNESDXsWAAA],null,null,9,null,null,1]
+			readHex: "8f0109d82a49000182e20392200100800203420004420005490053444835ec580000f6f609f6f601",
 			// extra field at the end on write, zero BigInt (bytes) for daily_fee
-			// [1,9,{"/":"bagboea4seaaqa"},[],2,3,[AAQ],[AAU],[AFNESDXsWAAA],[AGEk/umTvAAA],[AG8FtZ07IAAA],9,[AIrHIwSJ6AAA],null,1,[]]
-			writeHex: "900109d82a49000182e20392200100800203420004420005490053444835ec58000049006124fee993bc000049006f05b59d3b2000000949008ac7230489e80000f60140",
+			// [1,9,{"/":"bagboea4seaaqa"},[],2,3,[AAQ],[AAU],[AFNESDXsWAAA],null,null,9,null,null,1,[]]
+			writeHex: "900109d82a49000182e20392200100800203420004420005490053444835ec580000f6f609f6f60140",
 		},
 	}
 


### PR DESCRIPTION
Apparently also we've never used a nullable `big.Int` before, so I had to introduce that here as well as the 3 new nullable fields in https://github.com/filecoin-project/builtin-actors/pull/1639

The serialization tests in here had their hex copy/pasted from builtin-actors, so the fact that they pass means they match, at least for those cases. Also nice just how much smaller they are now with them nulled.