### PR TITLE
chore: map nv26 (Tock) to actors version 16

### DIFF
--- a/actors/version.go
+++ b/actors/version.go
@@ -60,7 +60,7 @@ func VersionForNetwork(version network.Version) (Version, error) {
 		return Version14, nil
 	case network.Version24:
 		return Version15, nil
-	case network.Version25:
+	case network.Version25, network.Version26:
 		return Version16, nil
 	default:
 		return -1, fmt.Errorf("unsupported network version %d", version)


### PR DESCRIPTION
Need this to be set properly for testing the nv24->nv25->nv26 upgrade flow in integration tests.