### PR TITLE
feat(v16): avoid seralizing the deprecated deal IDs field

### DIFF
--- a/builtin/v16/miner/miner_state.go
+++ b/builtin/v16/miner/miner_state.go
@@ -169,18 +169,18 @@ type SectorOnChainInfo struct {
 	SectorNumber          abi.SectorNumber
 	SealProof             abi.RegisteredSealProof // The seal proof type implies the PoSt proof/s
 	SealedCID             cid.Cid                 // CommR
-	DeprecatedDealIDs     []abi.DealID
-	Activation            abi.ChainEpoch         // Epoch during which the sector proof was accepted
-	Expiration            abi.ChainEpoch         // Epoch during which the sector expires
-	DealWeight            abi.DealWeight         // Integral of active deals over sector lifetime
-	VerifiedDealWeight    abi.DealWeight         // Integral of active verified deals over sector lifetime
-	InitialPledge         abi.TokenAmount        // Pledge collected to commit this sector
-	ExpectedDayReward     *abi.TokenAmount       // Expected one day projection of reward for sector computed at activation time
-	ExpectedStoragePledge *abi.TokenAmount       // Expected twenty day projection of reward for sector computed at activation time
-	PowerBaseEpoch        abi.ChainEpoch         // Epoch at which this sector's power was most recently updated
-	ReplacedDayReward     *abi.TokenAmount       // Day reward of this sector before its power was most recently updated
-	SectorKeyCID          *cid.Cid               // The original SealedSectorCID, only gets set on the first ReplicaUpdate
-	Flags                 SectorOnChainInfoFlags // Additional flags
+	DeprecatedDealIDs     []abi.DealID            `json:"-"`
+	Activation            abi.ChainEpoch          // Epoch during which the sector proof was accepted
+	Expiration            abi.ChainEpoch          // Epoch during which the sector expires
+	DealWeight            abi.DealWeight          // Integral of active deals over sector lifetime
+	VerifiedDealWeight    abi.DealWeight          // Integral of active verified deals over sector lifetime
+	InitialPledge         abi.TokenAmount         // Pledge collected to commit this sector
+	ExpectedDayReward     *abi.TokenAmount        // Expected one day projection of reward for sector computed at activation time
+	ExpectedStoragePledge *abi.TokenAmount        // Expected twenty day projection of reward for sector computed at activation time
+	PowerBaseEpoch        abi.ChainEpoch          // Epoch at which this sector's power was most recently updated
+	ReplacedDayReward     *abi.TokenAmount        // Day reward of this sector before its power was most recently updated
+	SectorKeyCID          *cid.Cid                // The original SealedSectorCID, only gets set on the first ReplicaUpdate
+	Flags                 SectorOnChainInfoFlags  // Additional flags
 	// The total fee payable per day for this sector. The value of this field is set at the time of
 	// sector activation, extension and whenever a sector's QAP is changed. This fee is payable for
 	// the lifetime of the sector and is aggregated in the deadline's `daily_fee` field.


### PR DESCRIPTION
I've left the FIP0098 fields as they'll remain relevant until the upgrade. But the deal IDs are now totally dead.