### PR TITLE
feat: cbor encoding of all referenced param & return types

### DIFF
--- a/abi/cbor_test.go
+++ b/abi/cbor_test.go
@@ -22,3 +22,45 @@ func TestCborBytesTransparent(t *testing.T) {
 	require.NoError(t, bytesDeSer.UnmarshalCBOR(bytes.NewReader(tBytes)))
 	require.Equal(t, tBytes, bytesDeSer)
 }
+
+func TestCborSectorSize(t *testing.T) {
+	tSectorSize := abi.SectorSize(20 * 1024)
+
+	buf := new(bytes.Buffer)
+	require.NoError(t, tSectorSize.MarshalCBOR(buf))
+
+	sectorSizeSer := buf.Bytes()
+	t.Logf("Serialized SectorSize: %x", sectorSizeSer)
+
+	var sectorSizeDeSer abi.SectorSize
+	require.NoError(t, sectorSizeDeSer.UnmarshalCBOR(bytes.NewReader(sectorSizeSer)))
+	require.Equal(t, tSectorSize, sectorSizeDeSer)
+
+	var nullSectorSize *abi.SectorSize
+	buf = new(bytes.Buffer)
+	require.NoError(t, nullSectorSize.MarshalCBOR(buf))
+	require.Equal(t, []byte{0xf6}, buf.Bytes(), "null SectorSize should serialize to CBOR null")
+	require.NoError(t, nullSectorSize.UnmarshalCBOR(bytes.NewReader([]byte{0xf6})))
+	require.Nil(t, nullSectorSize, "unmarshaled null SectorSize should be nil")
+}
+
+func TestCborSectorNumber(t *testing.T) {
+	tSectorNumber := abi.SectorNumber(42)
+
+	buf := new(bytes.Buffer)
+	require.NoError(t, tSectorNumber.MarshalCBOR(buf))
+
+	sectorNumberSer := buf.Bytes()
+	t.Logf("Serialized SectorNumber: %x", sectorNumberSer)
+
+	var sectorNumberDeSer abi.SectorNumber
+	require.NoError(t, sectorNumberDeSer.UnmarshalCBOR(bytes.NewReader(sectorNumberSer)))
+	require.Equal(t, tSectorNumber, sectorNumberDeSer)
+
+	var nullSectorNumber *abi.SectorNumber
+	buf = new(bytes.Buffer)
+	require.NoError(t, nullSectorNumber.MarshalCBOR(buf))
+	require.Equal(t, []byte{0xf6}, buf.Bytes(), "null SectorNumber should serialize to CBOR null")
+	require.NoError(t, nullSectorNumber.UnmarshalCBOR(bytes.NewReader([]byte{0xf6})))
+	require.Nil(t, nullSectorNumber, "unmarshaled null SectorNumber should be nil")
+}

--- a/abi/cbor_uint_types.go
+++ b/abi/cbor_uint_types.go
@@ -1,0 +1,94 @@
+package abi
+
+import (
+	"fmt"
+	"io"
+
+	cbg "github.com/whyrusleeping/cbor-gen"
+)
+
+// marshalNullableUint64 is a helper for marshaling nullable uint64 types
+func marshalNullableUint64(w io.Writer, v *uint64) error {
+	if v == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajUnsignedInt, *v); err != nil {
+		return err
+	}
+	return nil
+}
+
+// unmarshalNullableUint64 is a helper for unmarshaling nullable uint64 types
+func unmarshalNullableUint64(r io.Reader, v *uint64, typeName string) error {
+	cr := cbg.NewCborReader(r)
+	b, err := cr.ReadByte()
+	if err != nil {
+		return fmt.Errorf("failed to read byte for %s: %w", typeName, err)
+	}
+	if b == cbg.CborNull[0] {
+		// Null value - don't modify v as it might be nil
+		// Just return as we've successfully read a null
+		return nil
+	}
+
+	cr.UnreadByte()
+	maj, extra, err := cbg.CborReadHeader(cr)
+	if err != nil {
+		return fmt.Errorf("failed to parse CBOR header for %s: %w", typeName, err)
+	}
+
+	if maj != cbg.MajUnsignedInt {
+		return fmt.Errorf("wrong type for %s field: %d", typeName, maj)
+	}
+
+	*v = extra
+	return nil
+}
+
+func (t *SectorSize) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	return marshalNullableUint64(w, (*uint64)(t))
+}
+
+func (t *SectorSize) UnmarshalCBOR(r io.Reader) error {
+	if t == nil {
+		// Just consume the value without storing it
+		var dummy uint64
+		return unmarshalNullableUint64(r, &dummy, "SectorSize")
+	}
+
+	value := uint64(*t)
+	if err := unmarshalNullableUint64(r, &value, "SectorSize"); err != nil {
+		return err
+	}
+	*t = SectorSize(value)
+	return nil
+}
+
+func (t *SectorNumber) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	return marshalNullableUint64(w, (*uint64)(t))
+}
+
+func (t *SectorNumber) UnmarshalCBOR(r io.Reader) error {
+	if t == nil {
+		// Just consume the value without storing it
+		var dummy uint64
+		return unmarshalNullableUint64(r, &dummy, "SectorNumber")
+	}
+
+	value := uint64(*t)
+	if err := unmarshalNullableUint64(r, &value, "SectorNumber"); err != nil {
+		return err
+	}
+	*t = SectorNumber(value)
+	return nil
+}

--- a/builtin/v10/gen/gen.go
+++ b/builtin/v10/gen/gen.go
@@ -41,6 +41,7 @@ func main() {
 		cron.State{},
 		cron.Entry{},
 		// method params and returns
+		cron.ConstructorParams{},
 	); err != nil {
 		panic(err)
 	}

--- a/builtin/v11/gen/gen.go
+++ b/builtin/v11/gen/gen.go
@@ -41,6 +41,7 @@ func main() {
 		cron.State{},
 		cron.Entry{},
 		// method params and returns
+		cron.ConstructorParams{},
 	); err != nil {
 		panic(err)
 	}

--- a/builtin/v12/gen/gen.go
+++ b/builtin/v12/gen/gen.go
@@ -42,6 +42,7 @@ func main() {
 		cron.State{},
 		cron.Entry{},
 		// method params and returns
+		cron.ConstructorParams{},
 	); err != nil {
 		panic(err)
 	}

--- a/builtin/v13/gen/gen.go
+++ b/builtin/v13/gen/gen.go
@@ -42,6 +42,7 @@ func main() {
 		cron.State{},
 		cron.Entry{},
 		// method params and returns
+		cron.ConstructorParams{},
 	); err != nil {
 		panic(err)
 	}
@@ -161,7 +162,6 @@ func main() {
 		miner.BeneficiaryTerm{},
 		miner.PendingBeneficiaryChange{},
 		// method params and returns
-
 		miner.GetControlAddressesReturn{},
 		miner.ChangeWorkerAddressParams{},
 		miner.ChangePeerIDParams{},
@@ -204,6 +204,10 @@ func main() {
 		miner.SectorUpdateManifest{},
 		miner.SectorChanges{},
 		miner.PieceChange{},
+		miner.SectorContentChangedParams{},
+		miner.PieceReturn{},
+		miner.SectorReturn{},
+		miner.SectorContentChangedReturn{},
 		// other types
 		miner.FaultDeclaration{},
 		miner.RecoveryDeclaration{},

--- a/builtin/v13/miner/cbor_gen.go
+++ b/builtin/v13/miner/cbor_gen.go
@@ -8026,7 +8026,7 @@ func (t *PieceReturn) MarshalCBOR(w io.Writer) error {
 	cw := cbg.NewCborWriter(w)
 
 	// t.Accepted (bool) (bool)
-	if err := cbg.WriteBool(w, t.Accepted); err != nil {
+	if err := cbg.WriteBool(cw, t.Accepted); err != nil {
 		return err
 	}
 	return nil

--- a/builtin/v13/miner/cbor_gen.go
+++ b/builtin/v13/miner/cbor_gen.go
@@ -7953,6 +7953,251 @@ func (t *PieceChange) UnmarshalCBOR(r io.Reader) (err error) {
 	return nil
 }
 
+func (t *SectorContentChangedParams) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// t.Changes ([]miner.SectorChanges) (slice)
+	if len(t.Changes) > 8192 {
+		return xerrors.Errorf("Slice value in field t.Changes was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Changes))); err != nil {
+		return err
+	}
+	for _, v := range t.Changes {
+		if err := v.MarshalCBOR(cw); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (t *SectorContentChangedParams) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = SectorContentChangedParams{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// t.Changes ([]miner.SectorChanges) (slice)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if extra > 8192 {
+		return fmt.Errorf("t.Changes: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.Changes = make([]SectorChanges, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+			_ = maj
+			_ = extra
+			_ = err
+
+			{
+
+				if err := t.Changes[i].UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Changes[i]: %w", err)
+				}
+
+			}
+
+		}
+	}
+	return nil
+}
+
+func (t *PieceReturn) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// t.Accepted (bool) (bool)
+	if err := cbg.WriteBool(w, t.Accepted); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *PieceReturn) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = PieceReturn{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// t.Accepted (bool) (bool)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajOther {
+		return fmt.Errorf("booleans must be major type 7")
+	}
+	switch extra {
+	case 20:
+		t.Accepted = false
+	case 21:
+		t.Accepted = true
+	default:
+		return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
+	}
+	return nil
+}
+
+func (t *SectorReturn) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// t.Pieces ([]miner.PieceReturn) (slice)
+	if len(t.Pieces) > 8192 {
+		return xerrors.Errorf("Slice value in field t.Pieces was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Pieces))); err != nil {
+		return err
+	}
+	for _, v := range t.Pieces {
+		if err := v.MarshalCBOR(cw); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (t *SectorReturn) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = SectorReturn{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// t.Pieces ([]miner.PieceReturn) (slice)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if extra > 8192 {
+		return fmt.Errorf("t.Pieces: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.Pieces = make([]PieceReturn, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+			_ = maj
+			_ = extra
+			_ = err
+
+			{
+
+				if err := t.Pieces[i].UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Pieces[i]: %w", err)
+				}
+
+			}
+
+		}
+	}
+	return nil
+}
+
+func (t *SectorContentChangedReturn) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// t.Changes ([]miner.SectorReturn) (slice)
+	if len(t.Changes) > 8192 {
+		return xerrors.Errorf("Slice value in field t.Changes was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Changes))); err != nil {
+		return err
+	}
+	for _, v := range t.Changes {
+		if err := v.MarshalCBOR(cw); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (t *SectorContentChangedReturn) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = SectorContentChangedReturn{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// t.Changes ([]miner.SectorReturn) (slice)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if extra > 8192 {
+		return fmt.Errorf("t.Changes: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.Changes = make([]SectorReturn, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+			_ = maj
+			_ = extra
+			_ = err
+
+			{
+
+				if err := t.Changes[i].UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Changes[i]: %w", err)
+				}
+
+			}
+
+		}
+	}
+	return nil
+}
+
 var lengthBufFaultDeclaration = []byte{131}
 
 func (t *FaultDeclaration) MarshalCBOR(w io.Writer) error {

--- a/builtin/v13/miner/miner_types.go
+++ b/builtin/v13/miner/miner_types.go
@@ -462,7 +462,9 @@ type SectorUpdateManifest struct {
 type ProveReplicaUpdates3Return = batch.BatchReturn
 
 // SectorContentChangedParams represents a notification of change committed to sectors.
-type SectorContentChangedParams = []SectorChanges
+type SectorContentChangedParams struct {
+	Changes []SectorChanges `cborgen:"transparent"`
+}
 
 // SectorChanges describes changes to one sector's content.
 type SectorChanges struct {
@@ -479,10 +481,16 @@ type PieceChange struct {
 }
 
 // SectorContentChangedReturn represents the return value for the SectorContentChanged function.
-type SectorContentChangedReturn = []SectorReturn
+type SectorContentChangedReturn struct {
+	Changes []SectorReturn `cborgen:"transparent"`
+}
 
 // SectorReturn represents a result for each sector that was notified.
-type SectorReturn = []PieceReturn
+type SectorReturn struct {
+	Pieces []PieceReturn `cborgen:"transparent"`
+}
 
 // PieceReturn represents a result for each piece for the sector that was notified.
-type PieceReturn = bool // Accepted = true
+type PieceReturn struct {
+	Accepted bool `cborgen:"transparent"`
+}

--- a/builtin/v14/gen/gen.go
+++ b/builtin/v14/gen/gen.go
@@ -42,6 +42,7 @@ func main() {
 		cron.State{},
 		cron.Entry{},
 		// method params and returns
+		cron.ConstructorParams{},
 	); err != nil {
 		panic(err)
 	}
@@ -161,7 +162,6 @@ func main() {
 		miner.BeneficiaryTerm{},
 		miner.PendingBeneficiaryChange{},
 		// method params and returns
-
 		miner.GetControlAddressesReturn{},
 		miner.ChangeWorkerAddressParams{},
 		miner.ChangePeerIDParams{},
@@ -204,6 +204,10 @@ func main() {
 		miner.SectorUpdateManifest{},
 		miner.SectorChanges{},
 		miner.PieceChange{},
+		miner.SectorContentChangedParams{},
+		miner.PieceReturn{},
+		miner.SectorReturn{},
+		miner.SectorContentChangedReturn{},
 		// other types
 		miner.FaultDeclaration{},
 		miner.RecoveryDeclaration{},

--- a/builtin/v14/miner/cbor_gen.go
+++ b/builtin/v14/miner/cbor_gen.go
@@ -8026,7 +8026,7 @@ func (t *PieceReturn) MarshalCBOR(w io.Writer) error {
 	cw := cbg.NewCborWriter(w)
 
 	// t.Accepted (bool) (bool)
-	if err := cbg.WriteBool(w, t.Accepted); err != nil {
+	if err := cbg.WriteBool(cw, t.Accepted); err != nil {
 		return err
 	}
 	return nil

--- a/builtin/v14/miner/cbor_gen.go
+++ b/builtin/v14/miner/cbor_gen.go
@@ -7953,6 +7953,251 @@ func (t *PieceChange) UnmarshalCBOR(r io.Reader) (err error) {
 	return nil
 }
 
+func (t *SectorContentChangedParams) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// t.Changes ([]miner.SectorChanges) (slice)
+	if len(t.Changes) > 8192 {
+		return xerrors.Errorf("Slice value in field t.Changes was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Changes))); err != nil {
+		return err
+	}
+	for _, v := range t.Changes {
+		if err := v.MarshalCBOR(cw); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (t *SectorContentChangedParams) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = SectorContentChangedParams{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// t.Changes ([]miner.SectorChanges) (slice)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if extra > 8192 {
+		return fmt.Errorf("t.Changes: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.Changes = make([]SectorChanges, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+			_ = maj
+			_ = extra
+			_ = err
+
+			{
+
+				if err := t.Changes[i].UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Changes[i]: %w", err)
+				}
+
+			}
+
+		}
+	}
+	return nil
+}
+
+func (t *PieceReturn) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// t.Accepted (bool) (bool)
+	if err := cbg.WriteBool(w, t.Accepted); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *PieceReturn) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = PieceReturn{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// t.Accepted (bool) (bool)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajOther {
+		return fmt.Errorf("booleans must be major type 7")
+	}
+	switch extra {
+	case 20:
+		t.Accepted = false
+	case 21:
+		t.Accepted = true
+	default:
+		return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
+	}
+	return nil
+}
+
+func (t *SectorReturn) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// t.Pieces ([]miner.PieceReturn) (slice)
+	if len(t.Pieces) > 8192 {
+		return xerrors.Errorf("Slice value in field t.Pieces was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Pieces))); err != nil {
+		return err
+	}
+	for _, v := range t.Pieces {
+		if err := v.MarshalCBOR(cw); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (t *SectorReturn) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = SectorReturn{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// t.Pieces ([]miner.PieceReturn) (slice)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if extra > 8192 {
+		return fmt.Errorf("t.Pieces: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.Pieces = make([]PieceReturn, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+			_ = maj
+			_ = extra
+			_ = err
+
+			{
+
+				if err := t.Pieces[i].UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Pieces[i]: %w", err)
+				}
+
+			}
+
+		}
+	}
+	return nil
+}
+
+func (t *SectorContentChangedReturn) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// t.Changes ([]miner.SectorReturn) (slice)
+	if len(t.Changes) > 8192 {
+		return xerrors.Errorf("Slice value in field t.Changes was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Changes))); err != nil {
+		return err
+	}
+	for _, v := range t.Changes {
+		if err := v.MarshalCBOR(cw); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (t *SectorContentChangedReturn) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = SectorContentChangedReturn{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// t.Changes ([]miner.SectorReturn) (slice)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if extra > 8192 {
+		return fmt.Errorf("t.Changes: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.Changes = make([]SectorReturn, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+			_ = maj
+			_ = extra
+			_ = err
+
+			{
+
+				if err := t.Changes[i].UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Changes[i]: %w", err)
+				}
+
+			}
+
+		}
+	}
+	return nil
+}
+
 var lengthBufFaultDeclaration = []byte{131}
 
 func (t *FaultDeclaration) MarshalCBOR(w io.Writer) error {

--- a/builtin/v14/miner/miner_types.go
+++ b/builtin/v14/miner/miner_types.go
@@ -462,7 +462,9 @@ type SectorUpdateManifest struct {
 type ProveReplicaUpdates3Return = batch.BatchReturn
 
 // SectorContentChangedParams represents a notification of change committed to sectors.
-type SectorContentChangedParams = []SectorChanges
+type SectorContentChangedParams struct {
+	Changes []SectorChanges `cborgen:"transparent"`
+}
 
 // SectorChanges describes changes to one sector's content.
 type SectorChanges struct {
@@ -479,13 +481,19 @@ type PieceChange struct {
 }
 
 // SectorContentChangedReturn represents the return value for the SectorContentChanged function.
-type SectorContentChangedReturn = []SectorReturn
+type SectorContentChangedReturn struct {
+	Changes []SectorReturn `cborgen:"transparent"`
+}
 
 // SectorReturn represents a result for each sector that was notified.
-type SectorReturn = []PieceReturn
+type SectorReturn struct {
+	Pieces []PieceReturn `cborgen:"transparent"`
+}
 
 // PieceReturn represents a result for each piece for the sector that was notified.
-type PieceReturn = bool // Accepted = true
+type PieceReturn struct {
+	Accepted bool `cborgen:"transparent"`
+}
 
 // SectorNIActivationInfo is the information needed to activate a sector with a "zero" replica.
 type SectorNIActivationInfo struct {

--- a/builtin/v15/gen/gen.go
+++ b/builtin/v15/gen/gen.go
@@ -42,6 +42,7 @@ func main() {
 		cron.State{},
 		cron.Entry{},
 		// method params and returns
+		cron.ConstructorParams{},
 	); err != nil {
 		panic(err)
 	}
@@ -161,7 +162,6 @@ func main() {
 		miner.BeneficiaryTerm{},
 		miner.PendingBeneficiaryChange{},
 		// method params and returns
-
 		miner.GetControlAddressesReturn{},
 		miner.ChangeWorkerAddressParams{},
 		miner.ChangePeerIDParams{},
@@ -204,6 +204,10 @@ func main() {
 		miner.SectorUpdateManifest{},
 		miner.SectorChanges{},
 		miner.PieceChange{},
+		miner.SectorContentChangedParams{},
+		miner.PieceReturn{},
+		miner.SectorReturn{},
+		miner.SectorContentChangedReturn{},
 		// other types
 		miner.FaultDeclaration{},
 		miner.RecoveryDeclaration{},

--- a/builtin/v15/miner/cbor_gen.go
+++ b/builtin/v15/miner/cbor_gen.go
@@ -8026,7 +8026,7 @@ func (t *PieceReturn) MarshalCBOR(w io.Writer) error {
 	cw := cbg.NewCborWriter(w)
 
 	// t.Accepted (bool) (bool)
-	if err := cbg.WriteBool(w, t.Accepted); err != nil {
+	if err := cbg.WriteBool(cw, t.Accepted); err != nil {
 		return err
 	}
 	return nil

--- a/builtin/v15/miner/cbor_gen.go
+++ b/builtin/v15/miner/cbor_gen.go
@@ -7953,6 +7953,251 @@ func (t *PieceChange) UnmarshalCBOR(r io.Reader) (err error) {
 	return nil
 }
 
+func (t *SectorContentChangedParams) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// t.Changes ([]miner.SectorChanges) (slice)
+	if len(t.Changes) > 8192 {
+		return xerrors.Errorf("Slice value in field t.Changes was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Changes))); err != nil {
+		return err
+	}
+	for _, v := range t.Changes {
+		if err := v.MarshalCBOR(cw); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (t *SectorContentChangedParams) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = SectorContentChangedParams{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// t.Changes ([]miner.SectorChanges) (slice)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if extra > 8192 {
+		return fmt.Errorf("t.Changes: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.Changes = make([]SectorChanges, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+			_ = maj
+			_ = extra
+			_ = err
+
+			{
+
+				if err := t.Changes[i].UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Changes[i]: %w", err)
+				}
+
+			}
+
+		}
+	}
+	return nil
+}
+
+func (t *PieceReturn) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// t.Accepted (bool) (bool)
+	if err := cbg.WriteBool(w, t.Accepted); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *PieceReturn) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = PieceReturn{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// t.Accepted (bool) (bool)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajOther {
+		return fmt.Errorf("booleans must be major type 7")
+	}
+	switch extra {
+	case 20:
+		t.Accepted = false
+	case 21:
+		t.Accepted = true
+	default:
+		return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
+	}
+	return nil
+}
+
+func (t *SectorReturn) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// t.Pieces ([]miner.PieceReturn) (slice)
+	if len(t.Pieces) > 8192 {
+		return xerrors.Errorf("Slice value in field t.Pieces was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Pieces))); err != nil {
+		return err
+	}
+	for _, v := range t.Pieces {
+		if err := v.MarshalCBOR(cw); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (t *SectorReturn) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = SectorReturn{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// t.Pieces ([]miner.PieceReturn) (slice)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if extra > 8192 {
+		return fmt.Errorf("t.Pieces: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.Pieces = make([]PieceReturn, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+			_ = maj
+			_ = extra
+			_ = err
+
+			{
+
+				if err := t.Pieces[i].UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Pieces[i]: %w", err)
+				}
+
+			}
+
+		}
+	}
+	return nil
+}
+
+func (t *SectorContentChangedReturn) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// t.Changes ([]miner.SectorReturn) (slice)
+	if len(t.Changes) > 8192 {
+		return xerrors.Errorf("Slice value in field t.Changes was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Changes))); err != nil {
+		return err
+	}
+	for _, v := range t.Changes {
+		if err := v.MarshalCBOR(cw); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (t *SectorContentChangedReturn) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = SectorContentChangedReturn{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// t.Changes ([]miner.SectorReturn) (slice)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if extra > 8192 {
+		return fmt.Errorf("t.Changes: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.Changes = make([]SectorReturn, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+			_ = maj
+			_ = extra
+			_ = err
+
+			{
+
+				if err := t.Changes[i].UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Changes[i]: %w", err)
+				}
+
+			}
+
+		}
+	}
+	return nil
+}
+
 var lengthBufFaultDeclaration = []byte{131}
 
 func (t *FaultDeclaration) MarshalCBOR(w io.Writer) error {

--- a/builtin/v15/miner/miner_types.go
+++ b/builtin/v15/miner/miner_types.go
@@ -462,7 +462,9 @@ type SectorUpdateManifest struct {
 type ProveReplicaUpdates3Return = batch.BatchReturn
 
 // SectorContentChangedParams represents a notification of change committed to sectors.
-type SectorContentChangedParams = []SectorChanges
+type SectorContentChangedParams struct {
+	Changes []SectorChanges `cborgen:"transparent"`
+}
 
 // SectorChanges describes changes to one sector's content.
 type SectorChanges struct {
@@ -479,13 +481,19 @@ type PieceChange struct {
 }
 
 // SectorContentChangedReturn represents the return value for the SectorContentChanged function.
-type SectorContentChangedReturn = []SectorReturn
+type SectorContentChangedReturn struct {
+	Changes []SectorReturn `cborgen:"transparent"`
+}
 
 // SectorReturn represents a result for each sector that was notified.
-type SectorReturn = []PieceReturn
+type SectorReturn struct {
+	Pieces []PieceReturn `cborgen:"transparent"`
+}
 
 // PieceReturn represents a result for each piece for the sector that was notified.
-type PieceReturn = bool // Accepted = true
+type PieceReturn struct {
+	Accepted bool `cborgen:"transparent"`
+}
 
 // SectorNIActivationInfo is the information needed to activate a sector with a "zero" replica.
 type SectorNIActivationInfo struct {

--- a/builtin/v16/gen/gen.go
+++ b/builtin/v16/gen/gen.go
@@ -42,6 +42,7 @@ func main() {
 		cron.State{},
 		cron.Entry{},
 		// method params and returns
+		cron.ConstructorParams{},
 	); err != nil {
 		panic(err)
 	}
@@ -163,7 +164,6 @@ func main() {
 		miner.BeneficiaryTerm{},
 		miner.PendingBeneficiaryChange{},
 		// method params and returns
-
 		miner.GetControlAddressesReturn{},
 		miner.ChangeWorkerAddressParams{},
 		miner.ChangePeerIDParams{},
@@ -206,6 +206,10 @@ func main() {
 		miner.SectorUpdateManifest{},
 		miner.SectorChanges{},
 		miner.PieceChange{},
+		miner.SectorContentChangedParams{},
+		miner.PieceReturn{},
+		miner.SectorReturn{},
+		miner.SectorContentChangedReturn{},
 		// other types
 		miner.FaultDeclaration{},
 		miner.RecoveryDeclaration{},

--- a/builtin/v16/miner/cbor_gen.go
+++ b/builtin/v16/miner/cbor_gen.go
@@ -8184,7 +8184,7 @@ func (t *PieceReturn) MarshalCBOR(w io.Writer) error {
 	cw := cbg.NewCborWriter(w)
 
 	// t.Accepted (bool) (bool)
-	if err := cbg.WriteBool(w, t.Accepted); err != nil {
+	if err := cbg.WriteBool(cw, t.Accepted); err != nil {
 		return err
 	}
 	return nil

--- a/builtin/v16/miner/cbor_gen.go
+++ b/builtin/v16/miner/cbor_gen.go
@@ -8111,6 +8111,251 @@ func (t *PieceChange) UnmarshalCBOR(r io.Reader) (err error) {
 	return nil
 }
 
+func (t *SectorContentChangedParams) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// t.Changes ([]miner.SectorChanges) (slice)
+	if len(t.Changes) > 8192 {
+		return xerrors.Errorf("Slice value in field t.Changes was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Changes))); err != nil {
+		return err
+	}
+	for _, v := range t.Changes {
+		if err := v.MarshalCBOR(cw); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (t *SectorContentChangedParams) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = SectorContentChangedParams{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// t.Changes ([]miner.SectorChanges) (slice)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if extra > 8192 {
+		return fmt.Errorf("t.Changes: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.Changes = make([]SectorChanges, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+			_ = maj
+			_ = extra
+			_ = err
+
+			{
+
+				if err := t.Changes[i].UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Changes[i]: %w", err)
+				}
+
+			}
+
+		}
+	}
+	return nil
+}
+
+func (t *PieceReturn) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// t.Accepted (bool) (bool)
+	if err := cbg.WriteBool(w, t.Accepted); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *PieceReturn) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = PieceReturn{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// t.Accepted (bool) (bool)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajOther {
+		return fmt.Errorf("booleans must be major type 7")
+	}
+	switch extra {
+	case 20:
+		t.Accepted = false
+	case 21:
+		t.Accepted = true
+	default:
+		return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
+	}
+	return nil
+}
+
+func (t *SectorReturn) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// t.Pieces ([]miner.PieceReturn) (slice)
+	if len(t.Pieces) > 8192 {
+		return xerrors.Errorf("Slice value in field t.Pieces was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Pieces))); err != nil {
+		return err
+	}
+	for _, v := range t.Pieces {
+		if err := v.MarshalCBOR(cw); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (t *SectorReturn) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = SectorReturn{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// t.Pieces ([]miner.PieceReturn) (slice)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if extra > 8192 {
+		return fmt.Errorf("t.Pieces: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.Pieces = make([]PieceReturn, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+			_ = maj
+			_ = extra
+			_ = err
+
+			{
+
+				if err := t.Pieces[i].UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Pieces[i]: %w", err)
+				}
+
+			}
+
+		}
+	}
+	return nil
+}
+
+func (t *SectorContentChangedReturn) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// t.Changes ([]miner.SectorReturn) (slice)
+	if len(t.Changes) > 8192 {
+		return xerrors.Errorf("Slice value in field t.Changes was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Changes))); err != nil {
+		return err
+	}
+	for _, v := range t.Changes {
+		if err := v.MarshalCBOR(cw); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (t *SectorContentChangedReturn) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = SectorContentChangedReturn{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// t.Changes ([]miner.SectorReturn) (slice)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if extra > 8192 {
+		return fmt.Errorf("t.Changes: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.Changes = make([]SectorReturn, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+			_ = maj
+			_ = extra
+			_ = err
+
+			{
+
+				if err := t.Changes[i].UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Changes[i]: %w", err)
+				}
+
+			}
+
+		}
+	}
+	return nil
+}
+
 var lengthBufFaultDeclaration = []byte{131}
 
 func (t *FaultDeclaration) MarshalCBOR(w io.Writer) error {

--- a/builtin/v16/miner/miner_types.go
+++ b/builtin/v16/miner/miner_types.go
@@ -469,7 +469,9 @@ type SectorUpdateManifest struct {
 type ProveReplicaUpdates3Return = batch.BatchReturn
 
 // SectorContentChangedParams represents a notification of change committed to sectors.
-type SectorContentChangedParams = []SectorChanges
+type SectorContentChangedParams struct {
+	Changes []SectorChanges `cborgen:"transparent"`
+}
 
 // SectorChanges describes changes to one sector's content.
 type SectorChanges struct {
@@ -486,13 +488,19 @@ type PieceChange struct {
 }
 
 // SectorContentChangedReturn represents the return value for the SectorContentChanged function.
-type SectorContentChangedReturn = []SectorReturn
+type SectorContentChangedReturn struct {
+	Changes []SectorReturn `cborgen:"transparent"`
+}
 
 // SectorReturn represents a result for each sector that was notified.
-type SectorReturn = []PieceReturn
+type SectorReturn struct {
+	Pieces []PieceReturn `cborgen:"transparent"`
+}
 
 // PieceReturn represents a result for each piece for the sector that was notified.
-type PieceReturn = bool // Accepted = true
+type PieceReturn struct {
+	Accepted bool `cborgen:"transparent"`
+}
 
 // SectorNIActivationInfo is the information needed to activate a sector with a "zero" replica.
 type SectorNIActivationInfo struct {

--- a/builtin/v17/gen/gen.go
+++ b/builtin/v17/gen/gen.go
@@ -42,6 +42,7 @@ func main() {
 		cron.State{},
 		cron.Entry{},
 		// method params and returns
+		cron.ConstructorParams{},
 	); err != nil {
 		panic(err)
 	}
@@ -163,7 +164,6 @@ func main() {
 		miner.BeneficiaryTerm{},
 		miner.PendingBeneficiaryChange{},
 		// method params and returns
-
 		miner.GetControlAddressesReturn{},
 		miner.ChangeWorkerAddressParams{},
 		miner.ChangePeerIDParams{},
@@ -206,6 +206,10 @@ func main() {
 		miner.SectorUpdateManifest{},
 		miner.SectorChanges{},
 		miner.PieceChange{},
+		miner.SectorContentChangedParams{},
+		miner.PieceReturn{},
+		miner.SectorReturn{},
+		miner.SectorContentChangedReturn{},
 		// other types
 		miner.FaultDeclaration{},
 		miner.RecoveryDeclaration{},

--- a/builtin/v17/miner/cbor_gen.go
+++ b/builtin/v17/miner/cbor_gen.go
@@ -8184,7 +8184,7 @@ func (t *PieceReturn) MarshalCBOR(w io.Writer) error {
 	cw := cbg.NewCborWriter(w)
 
 	// t.Accepted (bool) (bool)
-	if err := cbg.WriteBool(w, t.Accepted); err != nil {
+	if err := cbg.WriteBool(cw, t.Accepted); err != nil {
 		return err
 	}
 	return nil

--- a/builtin/v17/miner/cbor_gen.go
+++ b/builtin/v17/miner/cbor_gen.go
@@ -8111,6 +8111,251 @@ func (t *PieceChange) UnmarshalCBOR(r io.Reader) (err error) {
 	return nil
 }
 
+func (t *SectorContentChangedParams) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// t.Changes ([]miner.SectorChanges) (slice)
+	if len(t.Changes) > 8192 {
+		return xerrors.Errorf("Slice value in field t.Changes was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Changes))); err != nil {
+		return err
+	}
+	for _, v := range t.Changes {
+		if err := v.MarshalCBOR(cw); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (t *SectorContentChangedParams) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = SectorContentChangedParams{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// t.Changes ([]miner.SectorChanges) (slice)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if extra > 8192 {
+		return fmt.Errorf("t.Changes: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.Changes = make([]SectorChanges, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+			_ = maj
+			_ = extra
+			_ = err
+
+			{
+
+				if err := t.Changes[i].UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Changes[i]: %w", err)
+				}
+
+			}
+
+		}
+	}
+	return nil
+}
+
+func (t *PieceReturn) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// t.Accepted (bool) (bool)
+	if err := cbg.WriteBool(w, t.Accepted); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *PieceReturn) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = PieceReturn{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// t.Accepted (bool) (bool)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajOther {
+		return fmt.Errorf("booleans must be major type 7")
+	}
+	switch extra {
+	case 20:
+		t.Accepted = false
+	case 21:
+		t.Accepted = true
+	default:
+		return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
+	}
+	return nil
+}
+
+func (t *SectorReturn) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// t.Pieces ([]miner.PieceReturn) (slice)
+	if len(t.Pieces) > 8192 {
+		return xerrors.Errorf("Slice value in field t.Pieces was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Pieces))); err != nil {
+		return err
+	}
+	for _, v := range t.Pieces {
+		if err := v.MarshalCBOR(cw); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (t *SectorReturn) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = SectorReturn{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// t.Pieces ([]miner.PieceReturn) (slice)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if extra > 8192 {
+		return fmt.Errorf("t.Pieces: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.Pieces = make([]PieceReturn, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+			_ = maj
+			_ = extra
+			_ = err
+
+			{
+
+				if err := t.Pieces[i].UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Pieces[i]: %w", err)
+				}
+
+			}
+
+		}
+	}
+	return nil
+}
+
+func (t *SectorContentChangedReturn) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// t.Changes ([]miner.SectorReturn) (slice)
+	if len(t.Changes) > 8192 {
+		return xerrors.Errorf("Slice value in field t.Changes was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Changes))); err != nil {
+		return err
+	}
+	for _, v := range t.Changes {
+		if err := v.MarshalCBOR(cw); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (t *SectorContentChangedReturn) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = SectorContentChangedReturn{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// t.Changes ([]miner.SectorReturn) (slice)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if extra > 8192 {
+		return fmt.Errorf("t.Changes: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.Changes = make([]SectorReturn, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+			_ = maj
+			_ = extra
+			_ = err
+
+			{
+
+				if err := t.Changes[i].UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Changes[i]: %w", err)
+				}
+
+			}
+
+		}
+	}
+	return nil
+}
+
 var lengthBufFaultDeclaration = []byte{131}
 
 func (t *FaultDeclaration) MarshalCBOR(w io.Writer) error {

--- a/builtin/v17/miner/miner_types.go
+++ b/builtin/v17/miner/miner_types.go
@@ -469,7 +469,9 @@ type SectorUpdateManifest struct {
 type ProveReplicaUpdates3Return = batch.BatchReturn
 
 // SectorContentChangedParams represents a notification of change committed to sectors.
-type SectorContentChangedParams = []SectorChanges
+type SectorContentChangedParams struct {
+	Changes []SectorChanges `cborgen:"transparent"`
+}
 
 // SectorChanges describes changes to one sector's content.
 type SectorChanges struct {
@@ -486,13 +488,19 @@ type PieceChange struct {
 }
 
 // SectorContentChangedReturn represents the return value for the SectorContentChanged function.
-type SectorContentChangedReturn = []SectorReturn
+type SectorContentChangedReturn struct {
+	Changes []SectorReturn `cborgen:"transparent"`
+}
 
 // SectorReturn represents a result for each sector that was notified.
-type SectorReturn = []PieceReturn
+type SectorReturn struct {
+	Pieces []PieceReturn `cborgen:"transparent"`
+}
 
 // PieceReturn represents a result for each piece for the sector that was notified.
-type PieceReturn = bool // Accepted = true
+type PieceReturn struct {
+	Accepted bool `cborgen:"transparent"`
+}
 
 // SectorNIActivationInfo is the information needed to activate a sector with a "zero" replica.
 type SectorNIActivationInfo struct {

--- a/builtin/v8/gen/gen.go
+++ b/builtin/v8/gen/gen.go
@@ -48,6 +48,7 @@ func main() {
 		cron.State{},
 		cron.Entry{},
 		// method params and returns
+		cron.ConstructorParams{},
 	); err != nil {
 		panic(err)
 	}

--- a/builtin/v9/gen/gen.go
+++ b/builtin/v9/gen/gen.go
@@ -51,6 +51,7 @@ func main() {
 		cron.State{},
 		cron.Entry{},
 		// method params and returns
+		cron.ConstructorParams{},
 	); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Closes: https://github.com/filecoin-project/go-state-types/issues/396

`SectorContentChanged` is a little odd to include here, but it's referenced as in the market methods and uses the miner types for the call, which makes sense, but you don't typically even see it. Maybe if you were decoding internal calls between actors, or were doing some testing of a smart contract that uses it.

The *uint64 ones are because we have some methods that use them, `GetSectorSizeExported` and `GetDealSectorExported`. We don't really need the nullability, however, but we declare them as pointers in methods.go so we'll just be complete here.