### PR TITLE
fix: `StateEncodeParams` API panic with Market Actor SectorContentChanged method

### DIFF
--- a/builtin/v13/gen/gen.go
+++ b/builtin/v13/gen/gen.go
@@ -202,6 +202,7 @@ func main() {
 		miner.DataActivationNotification{},
 		miner.ProveReplicaUpdates3Params{},
 		miner.SectorUpdateManifest{},
+		miner.SectorContentChangedParams{},
 		miner.SectorChanges{},
 		miner.PieceChange{},
 		// other types

--- a/builtin/v13/miner/cbor_gen.go
+++ b/builtin/v13/miner/cbor_gen.go
@@ -7686,6 +7686,75 @@ func (t *SectorUpdateManifest) UnmarshalCBOR(r io.Reader) (err error) {
 	return nil
 }
 
+func (t *SectorContentChangedParams) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// (*t) (miner.SectorContentChangedParams) (slice)
+	if len((*t)) > 8192 {
+		return xerrors.Errorf("Slice value in field (*t) was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len((*t)))); err != nil {
+		return err
+	}
+	for _, v := range *t {
+		if err := v.MarshalCBOR(cw); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (t *SectorContentChangedParams) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = SectorContentChangedParams{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// (*t) (miner.SectorContentChangedParams) (slice)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if extra > 8192 {
+		return fmt.Errorf("(*t): array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		(*t) = make([]SectorChanges, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+			_ = maj
+			_ = extra
+			_ = err
+
+			{
+
+				if err := (*t)[i].UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling (*t)[i]: %w", err)
+				}
+
+			}
+
+		}
+	}
+	return nil
+}
+
 var lengthBufSectorChanges = []byte{131}
 
 func (t *SectorChanges) MarshalCBOR(w io.Writer) error {

--- a/builtin/v13/miner/miner_types.go
+++ b/builtin/v13/miner/miner_types.go
@@ -1,9 +1,6 @@
 package miner
 
 import (
-	"fmt"
-	"io"
-
 	cid "github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	"golang.org/x/xerrors"
@@ -483,57 +480,6 @@ type PieceChange struct {
 
 // SectorContentChangedReturn represents the return value for the SectorContentChanged function.
 type SectorContentChangedReturn = []SectorReturn
-
-// MarshalCBOR implements CBOR marshalling for SectorContentChangedParams
-func (t SectorContentChangedParams) MarshalCBOR(w io.Writer) error {
-	if len(t) > cbg.MaxLength {
-		return xerrors.Errorf("slice value in field t was too long")
-	}
-
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t))); err != nil {
-		return err
-	}
-
-	for _, v := range t {
-		if err := v.MarshalCBOR(w); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// UnmarshalCBOR implements CBOR unmarshalling for SectorContentChangedParams
-func (t *SectorContentChangedParams) UnmarshalCBOR(r io.Reader) error {
-	cr := cbg.NewCborReader(r)
-
-	maj, extra, err := cr.ReadHeader()
-	if err != nil {
-		return err
-	}
-
-	if extra > cbg.MaxLength {
-		return fmt.Errorf("t: array too large (%d)", extra)
-	}
-
-	if maj != cbg.MajArray {
-		return fmt.Errorf("expected cbor array")
-	}
-
-	if extra > 0 {
-		*t = make([]SectorChanges, extra)
-	}
-
-	for i := 0; i < int(extra); i++ {
-		var v SectorChanges
-		if err := v.UnmarshalCBOR(cr); err != nil {
-			return err
-		}
-
-		(*t)[i] = v
-	}
-
-	return nil
-}
 
 // SectorReturn represents a result for each sector that was notified.
 type SectorReturn = []PieceReturn

--- a/builtin/v14/gen/gen.go
+++ b/builtin/v14/gen/gen.go
@@ -202,6 +202,7 @@ func main() {
 		miner.DataActivationNotification{},
 		miner.ProveReplicaUpdates3Params{},
 		miner.SectorUpdateManifest{},
+		miner.SectorContentChangedParams{},
 		miner.SectorChanges{},
 		miner.PieceChange{},
 		// other types

--- a/builtin/v14/miner/cbor_gen.go
+++ b/builtin/v14/miner/cbor_gen.go
@@ -7686,6 +7686,75 @@ func (t *SectorUpdateManifest) UnmarshalCBOR(r io.Reader) (err error) {
 	return nil
 }
 
+func (t *SectorContentChangedParams) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// (*t) (miner.SectorContentChangedParams) (slice)
+	if len((*t)) > 8192 {
+		return xerrors.Errorf("Slice value in field (*t) was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len((*t)))); err != nil {
+		return err
+	}
+	for _, v := range *t {
+		if err := v.MarshalCBOR(cw); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (t *SectorContentChangedParams) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = SectorContentChangedParams{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// (*t) (miner.SectorContentChangedParams) (slice)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if extra > 8192 {
+		return fmt.Errorf("(*t): array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		(*t) = make([]SectorChanges, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+			_ = maj
+			_ = extra
+			_ = err
+
+			{
+
+				if err := (*t)[i].UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling (*t)[i]: %w", err)
+				}
+
+			}
+
+		}
+	}
+	return nil
+}
+
 var lengthBufSectorChanges = []byte{131}
 
 func (t *SectorChanges) MarshalCBOR(w io.Writer) error {

--- a/builtin/v14/miner/miner_types.go
+++ b/builtin/v14/miner/miner_types.go
@@ -1,9 +1,6 @@
 package miner
 
 import (
-	"fmt"
-	"io"
-
 	cid "github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	"golang.org/x/xerrors"
@@ -483,57 +480,6 @@ type PieceChange struct {
 
 // SectorContentChangedReturn represents the return value for the SectorContentChanged function.
 type SectorContentChangedReturn = []SectorReturn
-
-// MarshalCBOR implements CBOR marshalling for SectorContentChangedParams
-func (t SectorContentChangedParams) MarshalCBOR(w io.Writer) error {
-	if len(t) > cbg.MaxLength {
-		return xerrors.Errorf("slice value in field t was too long")
-	}
-
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t))); err != nil {
-		return err
-	}
-
-	for _, v := range t {
-		if err := v.MarshalCBOR(w); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// UnmarshalCBOR implements CBOR unmarshalling for SectorContentChangedParams
-func (t *SectorContentChangedParams) UnmarshalCBOR(r io.Reader) error {
-	cr := cbg.NewCborReader(r)
-
-	maj, extra, err := cr.ReadHeader()
-	if err != nil {
-		return err
-	}
-
-	if extra > cbg.MaxLength {
-		return fmt.Errorf("t: array too large (%d)", extra)
-	}
-
-	if maj != cbg.MajArray {
-		return fmt.Errorf("expected cbor array")
-	}
-
-	if extra > 0 {
-		*t = make([]SectorChanges, extra)
-	}
-
-	for i := 0; i < int(extra); i++ {
-		var v SectorChanges
-		if err := v.UnmarshalCBOR(cr); err != nil {
-			return err
-		}
-
-		(*t)[i] = v
-	}
-
-	return nil
-}
 
 // SectorReturn represents a result for each sector that was notified.
 type SectorReturn = []PieceReturn

--- a/builtin/v15/gen/gen.go
+++ b/builtin/v15/gen/gen.go
@@ -202,6 +202,7 @@ func main() {
 		miner.DataActivationNotification{},
 		miner.ProveReplicaUpdates3Params{},
 		miner.SectorUpdateManifest{},
+		miner.SectorContentChangedParams{},
 		miner.SectorChanges{},
 		miner.PieceChange{},
 		// other types

--- a/builtin/v15/miner/cbor_gen.go
+++ b/builtin/v15/miner/cbor_gen.go
@@ -7686,6 +7686,75 @@ func (t *SectorUpdateManifest) UnmarshalCBOR(r io.Reader) (err error) {
 	return nil
 }
 
+func (t *SectorContentChangedParams) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// (*t) (miner.SectorContentChangedParams) (slice)
+	if len((*t)) > 8192 {
+		return xerrors.Errorf("Slice value in field (*t) was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len((*t)))); err != nil {
+		return err
+	}
+	for _, v := range *t {
+		if err := v.MarshalCBOR(cw); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (t *SectorContentChangedParams) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = SectorContentChangedParams{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// (*t) (miner.SectorContentChangedParams) (slice)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if extra > 8192 {
+		return fmt.Errorf("(*t): array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		(*t) = make([]SectorChanges, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+			_ = maj
+			_ = extra
+			_ = err
+
+			{
+
+				if err := (*t)[i].UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling (*t)[i]: %w", err)
+				}
+
+			}
+
+		}
+	}
+	return nil
+}
+
 var lengthBufSectorChanges = []byte{131}
 
 func (t *SectorChanges) MarshalCBOR(w io.Writer) error {

--- a/builtin/v15/miner/miner_types.go
+++ b/builtin/v15/miner/miner_types.go
@@ -1,9 +1,6 @@
 package miner
 
 import (
-	"fmt"
-	"io"
-
 	cid "github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	"golang.org/x/xerrors"
@@ -483,57 +480,6 @@ type PieceChange struct {
 
 // SectorContentChangedReturn represents the return value for the SectorContentChanged function.
 type SectorContentChangedReturn = []SectorReturn
-
-// MarshalCBOR implements CBOR marshalling for SectorContentChangedParams
-func (t SectorContentChangedParams) MarshalCBOR(w io.Writer) error {
-	if len(t) > cbg.MaxLength {
-		return xerrors.Errorf("slice value in field t was too long")
-	}
-
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t))); err != nil {
-		return err
-	}
-
-	for _, v := range t {
-		if err := v.MarshalCBOR(w); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// UnmarshalCBOR implements CBOR unmarshalling for SectorContentChangedParams
-func (t *SectorContentChangedParams) UnmarshalCBOR(r io.Reader) error {
-	cr := cbg.NewCborReader(r)
-
-	maj, extra, err := cr.ReadHeader()
-	if err != nil {
-		return err
-	}
-
-	if extra > cbg.MaxLength {
-		return fmt.Errorf("t: array too large (%d)", extra)
-	}
-
-	if maj != cbg.MajArray {
-		return fmt.Errorf("expected cbor array")
-	}
-
-	if extra > 0 {
-		*t = make([]SectorChanges, extra)
-	}
-
-	for i := 0; i < int(extra); i++ {
-		var v SectorChanges
-		if err := v.UnmarshalCBOR(cr); err != nil {
-			return err
-		}
-
-		(*t)[i] = v
-	}
-
-	return nil
-}
 
 // SectorReturn represents a result for each sector that was notified.
 type SectorReturn = []PieceReturn

--- a/builtin/v16/gen/gen.go
+++ b/builtin/v16/gen/gen.go
@@ -204,6 +204,7 @@ func main() {
 		miner.DataActivationNotification{},
 		miner.ProveReplicaUpdates3Params{},
 		miner.SectorUpdateManifest{},
+		miner.SectorContentChangedParams{},
 		miner.SectorChanges{},
 		miner.PieceChange{},
 		// other types

--- a/builtin/v16/miner/cbor_gen.go
+++ b/builtin/v16/miner/cbor_gen.go
@@ -7844,6 +7844,75 @@ func (t *SectorUpdateManifest) UnmarshalCBOR(r io.Reader) (err error) {
 	return nil
 }
 
+func (t *SectorContentChangedParams) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// (*t) (miner.SectorContentChangedParams) (slice)
+	if len((*t)) > 8192 {
+		return xerrors.Errorf("Slice value in field (*t) was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len((*t)))); err != nil {
+		return err
+	}
+	for _, v := range *t {
+		if err := v.MarshalCBOR(cw); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (t *SectorContentChangedParams) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = SectorContentChangedParams{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// (*t) (miner.SectorContentChangedParams) (slice)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if extra > 8192 {
+		return fmt.Errorf("(*t): array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		(*t) = make([]SectorChanges, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+			_ = maj
+			_ = extra
+			_ = err
+
+			{
+
+				if err := (*t)[i].UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling (*t)[i]: %w", err)
+				}
+
+			}
+
+		}
+	}
+	return nil
+}
+
 var lengthBufSectorChanges = []byte{131}
 
 func (t *SectorChanges) MarshalCBOR(w io.Writer) error {

--- a/builtin/v16/miner/miner_types.go
+++ b/builtin/v16/miner/miner_types.go
@@ -1,9 +1,6 @@
 package miner
 
 import (
-	"fmt"
-	"io"
-
 	cid "github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	"golang.org/x/xerrors"
@@ -490,57 +487,6 @@ type PieceChange struct {
 
 // SectorContentChangedReturn represents the return value for the SectorContentChanged function.
 type SectorContentChangedReturn = []SectorReturn
-
-// MarshalCBOR implements CBOR marshalling for SectorContentChangedParams
-func (t SectorContentChangedParams) MarshalCBOR(w io.Writer) error {
-	if len(t) > cbg.MaxLength {
-		return xerrors.Errorf("slice value in field t was too long")
-	}
-
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t))); err != nil {
-		return err
-	}
-
-	for _, v := range t {
-		if err := v.MarshalCBOR(w); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// UnmarshalCBOR implements CBOR unmarshalling for SectorContentChangedParams
-func (t *SectorContentChangedParams) UnmarshalCBOR(r io.Reader) error {
-	cr := cbg.NewCborReader(r)
-
-	maj, extra, err := cr.ReadHeader()
-	if err != nil {
-		return err
-	}
-
-	if extra > cbg.MaxLength {
-		return fmt.Errorf("t: array too large (%d)", extra)
-	}
-
-	if maj != cbg.MajArray {
-		return fmt.Errorf("expected cbor array")
-	}
-
-	if extra > 0 {
-		*t = make([]SectorChanges, extra)
-	}
-
-	for i := 0; i < int(extra); i++ {
-		var v SectorChanges
-		if err := v.UnmarshalCBOR(cr); err != nil {
-			return err
-		}
-
-		(*t)[i] = v
-	}
-
-	return nil
-}
 
 // SectorReturn represents a result for each sector that was notified.
 type SectorReturn = []PieceReturn

--- a/builtin/v17/gen/gen.go
+++ b/builtin/v17/gen/gen.go
@@ -204,6 +204,7 @@ func main() {
 		miner.DataActivationNotification{},
 		miner.ProveReplicaUpdates3Params{},
 		miner.SectorUpdateManifest{},
+		miner.SectorContentChangedParams{},
 		miner.SectorChanges{},
 		miner.PieceChange{},
 		// other types

--- a/builtin/v17/miner/cbor_gen.go
+++ b/builtin/v17/miner/cbor_gen.go
@@ -7844,6 +7844,75 @@ func (t *SectorUpdateManifest) UnmarshalCBOR(r io.Reader) (err error) {
 	return nil
 }
 
+func (t *SectorContentChangedParams) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// (*t) (miner.SectorContentChangedParams) (slice)
+	if len((*t)) > 8192 {
+		return xerrors.Errorf("Slice value in field (*t) was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len((*t)))); err != nil {
+		return err
+	}
+	for _, v := range *t {
+		if err := v.MarshalCBOR(cw); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (t *SectorContentChangedParams) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = SectorContentChangedParams{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// (*t) (miner.SectorContentChangedParams) (slice)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if extra > 8192 {
+		return fmt.Errorf("(*t): array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		(*t) = make([]SectorChanges, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+			_ = maj
+			_ = extra
+			_ = err
+
+			{
+
+				if err := (*t)[i].UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling (*t)[i]: %w", err)
+				}
+
+			}
+
+		}
+	}
+	return nil
+}
+
 var lengthBufSectorChanges = []byte{131}
 
 func (t *SectorChanges) MarshalCBOR(w io.Writer) error {

--- a/builtin/v17/miner/miner_types.go
+++ b/builtin/v17/miner/miner_types.go
@@ -1,9 +1,6 @@
 package miner
 
 import (
-	"fmt"
-	"io"
-
 	cid "github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	"golang.org/x/xerrors"
@@ -490,57 +487,6 @@ type PieceChange struct {
 
 // SectorContentChangedReturn represents the return value for the SectorContentChanged function.
 type SectorContentChangedReturn = []SectorReturn
-
-// MarshalCBOR implements CBOR marshalling for SectorContentChangedParams
-func (t SectorContentChangedParams) MarshalCBOR(w io.Writer) error {
-	if len(t) > cbg.MaxLength {
-		return xerrors.Errorf("slice value in field t was too long")
-	}
-
-	if err := cbg.WriteMajorTypeHeader(w, cbg.MajArray, uint64(len(t))); err != nil {
-		return err
-	}
-
-	for _, v := range t {
-		if err := v.MarshalCBOR(w); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// UnmarshalCBOR implements CBOR unmarshalling for SectorContentChangedParams
-func (t *SectorContentChangedParams) UnmarshalCBOR(r io.Reader) error {
-	cr := cbg.NewCborReader(r)
-
-	maj, extra, err := cr.ReadHeader()
-	if err != nil {
-		return err
-	}
-
-	if extra > cbg.MaxLength {
-		return fmt.Errorf("t: array too large (%d)", extra)
-	}
-
-	if maj != cbg.MajArray {
-		return fmt.Errorf("expected cbor array")
-	}
-
-	if extra > 0 {
-		*t = make([]SectorChanges, extra)
-	}
-
-	for i := 0; i < int(extra); i++ {
-		var v SectorChanges
-		if err := v.UnmarshalCBOR(cr); err != nil {
-			return err
-		}
-
-		(*t)[i] = v
-	}
-
-	return nil
-}
 
 // SectorReturn represents a result for each sector that was notified.
 type SectorReturn = []PieceReturn


### PR DESCRIPTION
Fixes: https://github.com/filecoin-project/lotus/issues/13329

**Root Cause**
SectorContentChangedParams was defined as a type alias []SectorChanges, but CBOR-gen doesn't automatically generate marshalling methods for slice type aliases.

**Solution**
- Convert SectorContentChangedParams from type alias to proper type
- Add SectorContentChangedParams to gen.go files for automatic generation
- Regenerate CBOR marshalling methods using cbor-gen 