### PR TITLE
Replace ActivateDeals with BatchActivateDeals and update params (v12–latest)

### DIFF
--- a/builtin/v12/gen/gen.go
+++ b/builtin/v12/gen/gen.go
@@ -117,7 +117,7 @@ func main() {
 		market.WithdrawBalanceParams{},
 		market.PublishStorageDealsParams{},
 		market.PublishStorageDealsReturn{},
-		market.ActivateDealsParams{},
+		market.BatchActivateDealsParams{},
 		market.ActivateDealsResult{},
 		market.VerifyDealsForActivationParams{},
 		market.VerifyDealsForActivationReturn{},

--- a/builtin/v12/market/market_types.go
+++ b/builtin/v12/market/market_types.go
@@ -32,6 +32,7 @@ type VerifyDealsForActivationParams struct {
 }
 
 type SectorDeals struct {
+	SectorNumber abi.SectorNumber
 	SectorType   abi.RegisteredSealProof
 	SectorExpiry abi.ChainEpoch
 	DealIDs      []abi.DealID
@@ -42,9 +43,9 @@ type VerifyDealsForActivationReturn struct {
 	UnsealedCIDs []*cid.Cid
 }
 
-type ActivateDealsParams struct {
-	DealIDs      []abi.DealID
-	SectorExpiry abi.ChainEpoch
+type BatchActivateDealsParams struct {
+	Sectors    []SectorDeals
+	ComputeCid bool
 }
 
 type ActivateDealsResult struct {

--- a/builtin/v12/market/methods.go
+++ b/builtin/v12/market/methods.go
@@ -15,7 +15,7 @@ var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	4: builtin.NewMethodMeta("PublishStorageDeals", *new(func(*PublishStorageDealsParams) *PublishStorageDealsReturn)), // PublishStorageDeals
 	builtin.MustGenerateFRCMethodNum("PublishStorageDeals"): builtin.NewMethodMeta("PublishStorageDealsExported", *new(func(*PublishStorageDealsParams) *PublishStorageDealsReturn)), // PublishStorageDealsExported
 	5: builtin.NewMethodMeta("VerifyDealsForActivation", *new(func(*VerifyDealsForActivationParams) *VerifyDealsForActivationReturn)), // VerifyDealsForActivation
-	6: builtin.NewMethodMeta("ActivateDeals", *new(func(*ActivateDealsParams) *abi.EmptyValue)),                                       // ActivateDeals
+	6: builtin.NewMethodMeta("BatchActivateDeals", *new(func(*BatchActivateDealsParams) *abi.EmptyValue)),                                       // BatchActivateDeals
 	7: builtin.NewMethodMeta("OnMinerSectorsTerminate", *new(func(*OnMinerSectorsTerminateParams) *abi.EmptyValue)),                   // OnMinerSectorsTerminate
 	8: builtin.NewMethodMeta("ComputeDataCommitment", nil),                                                                            // deprecated
 	9: builtin.NewMethodMeta("CronTick", *new(func(*abi.EmptyValue) *abi.EmptyValue)),                                                 // CronTick

--- a/builtin/v12/market/methods.go
+++ b/builtin/v12/market/methods.go
@@ -15,7 +15,7 @@ var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	4: builtin.NewMethodMeta("PublishStorageDeals", *new(func(*PublishStorageDealsParams) *PublishStorageDealsReturn)), // PublishStorageDeals
 	builtin.MustGenerateFRCMethodNum("PublishStorageDeals"): builtin.NewMethodMeta("PublishStorageDealsExported", *new(func(*PublishStorageDealsParams) *PublishStorageDealsReturn)), // PublishStorageDealsExported
 	5: builtin.NewMethodMeta("VerifyDealsForActivation", *new(func(*VerifyDealsForActivationParams) *VerifyDealsForActivationReturn)), // VerifyDealsForActivation
-	6: builtin.NewMethodMeta("BatchActivateDeals", *new(func(*BatchActivateDealsParams) *abi.EmptyValue)),                                       // BatchActivateDeals
+	6: builtin.NewMethodMeta("BatchActivateDeals", *new(func(*BatchActivateDealsParams) *abi.EmptyValue)),                             // BatchActivateDeals
 	7: builtin.NewMethodMeta("OnMinerSectorsTerminate", *new(func(*OnMinerSectorsTerminateParams) *abi.EmptyValue)),                   // OnMinerSectorsTerminate
 	8: builtin.NewMethodMeta("ComputeDataCommitment", nil),                                                                            // deprecated
 	9: builtin.NewMethodMeta("CronTick", *new(func(*abi.EmptyValue) *abi.EmptyValue)),                                                 // CronTick

--- a/builtin/v13/gen/gen.go
+++ b/builtin/v13/gen/gen.go
@@ -118,7 +118,7 @@ func main() {
 		market.WithdrawBalanceParams{},
 		market.PublishStorageDealsParams{},
 		market.PublishStorageDealsReturn{},
-		market.ActivateDealsParams{},
+		market.BatchActivateDealsParams{},
 		market.ActivateDealsResult{},
 		market.VerifyDealsForActivationParams{},
 		market.VerifyDealsForActivationReturn{},

--- a/builtin/v13/market/cbor_gen.go
+++ b/builtin/v13/market/cbor_gen.go
@@ -831,9 +831,9 @@ func (t *PublishStorageDealsReturn) UnmarshalCBOR(r io.Reader) (err error) {
 	return nil
 }
 
-var lengthBufActivateDealsParams = []byte{130}
+var lengthBufBatchActivateDealsParams = []byte{130}
 
-func (t *ActivateDealsParams) MarshalCBOR(w io.Writer) error {
+func (t *BatchActivateDealsParams) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
@@ -841,42 +841,34 @@ func (t *ActivateDealsParams) MarshalCBOR(w io.Writer) error {
 
 	cw := cbg.NewCborWriter(w)
 
-	if _, err := cw.Write(lengthBufActivateDealsParams); err != nil {
+	if _, err := cw.Write(lengthBufBatchActivateDealsParams); err != nil {
 		return err
 	}
 
-	// t.DealIDs ([]abi.DealID) (slice)
-	if len(t.DealIDs) > 8192 {
-		return xerrors.Errorf("Slice value in field t.DealIDs was too long")
+	// t.Sectors ([]market.SectorDeals) (slice)
+	if len(t.Sectors) > 8192 {
+		return xerrors.Errorf("Slice value in field t.Sectors was too long")
 	}
 
-	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.DealIDs))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Sectors))); err != nil {
 		return err
 	}
-	for _, v := range t.DealIDs {
-
-		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(v)); err != nil {
+	for _, v := range t.Sectors {
+		if err := v.MarshalCBOR(cw); err != nil {
 			return err
 		}
 
 	}
 
-	// t.SectorExpiry (abi.ChainEpoch) (int64)
-	if t.SectorExpiry >= 0 {
-		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.SectorExpiry)); err != nil {
-			return err
-		}
-	} else {
-		if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-t.SectorExpiry-1)); err != nil {
-			return err
-		}
+	// t.ComputeCid (bool) (bool)
+	if err := cbg.WriteBool(w, t.ComputeCid); err != nil {
+		return err
 	}
-
 	return nil
 }
 
-func (t *ActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
-	*t = ActivateDealsParams{}
+func (t *BatchActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = BatchActivateDealsParams{}
 
 	cr := cbg.NewCborReader(r)
 
@@ -898,7 +890,7 @@ func (t *ActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.DealIDs ([]abi.DealID) (slice)
+	// t.Sectors ([]market.SectorDeals) (slice)
 
 	maj, extra, err = cr.ReadHeader()
 	if err != nil {
@@ -906,7 +898,7 @@ func (t *ActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 
 	if extra > 8192 {
-		return fmt.Errorf("t.DealIDs: array too large (%d)", extra)
+		return fmt.Errorf("t.Sectors: array too large (%d)", extra)
 	}
 
 	if maj != cbg.MajArray {
@@ -914,7 +906,7 @@ func (t *ActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 
 	if extra > 0 {
-		t.DealIDs = make([]abi.DealID, extra)
+		t.Sectors = make([]SectorDeals, extra)
 	}
 
 	for i := 0; i < int(extra); i++ {
@@ -928,43 +920,30 @@ func (t *ActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
 
 			{
 
-				maj, extra, err = cr.ReadHeader()
-				if err != nil {
-					return err
+				if err := t.Sectors[i].UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Sectors[i]: %w", err)
 				}
-				if maj != cbg.MajUnsignedInt {
-					return fmt.Errorf("wrong type for uint64 field")
-				}
-				t.DealIDs[i] = abi.DealID(extra)
 
 			}
 
 		}
 	}
-	// t.SectorExpiry (abi.ChainEpoch) (int64)
-	{
-		maj, extra, err := cr.ReadHeader()
-		if err != nil {
-			return err
-		}
-		var extraI int64
-		switch maj {
-		case cbg.MajUnsignedInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 positive overflow")
-			}
-		case cbg.MajNegativeInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 negative overflow")
-			}
-			extraI = -1 - extraI
-		default:
-			return fmt.Errorf("wrong type for int64 field: %d", maj)
-		}
+	// t.ComputeCid (bool) (bool)
 
-		t.SectorExpiry = abi.ChainEpoch(extraI)
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajOther {
+		return fmt.Errorf("booleans must be major type 7")
+	}
+	switch extra {
+	case 20:
+		t.ComputeCid = false
+	case 21:
+		t.ComputeCid = true
+	default:
+		return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
 	}
 	return nil
 }
@@ -2243,7 +2222,7 @@ func (t *ClientDealProposal) UnmarshalCBOR(r io.Reader) (err error) {
 	return nil
 }
 
-var lengthBufSectorDeals = []byte{131}
+var lengthBufSectorDeals = []byte{132}
 
 func (t *SectorDeals) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -2254,6 +2233,12 @@ func (t *SectorDeals) MarshalCBOR(w io.Writer) error {
 	cw := cbg.NewCborWriter(w)
 
 	if _, err := cw.Write(lengthBufSectorDeals); err != nil {
+		return err
+	}
+
+	// t.SectorNumber (abi.SectorNumber) (uint64)
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.SectorNumber)); err != nil {
 		return err
 	}
 
@@ -2316,10 +2301,24 @@ func (t *SectorDeals) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 3 {
+	if extra != 4 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
+	// t.SectorNumber (abi.SectorNumber) (uint64)
+
+	{
+
+		maj, extra, err = cr.ReadHeader()
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.SectorNumber = abi.SectorNumber(extra)
+
+	}
 	// t.SectorType (abi.RegisteredSealProof) (int64)
 	{
 		maj, extra, err := cr.ReadHeader()

--- a/builtin/v13/market/market_types.go
+++ b/builtin/v13/market/market_types.go
@@ -35,6 +35,7 @@ type VerifyDealsForActivationParams struct {
 }
 
 type SectorDeals struct {
+	SectorNumber abi.SectorNumber
 	SectorType   abi.RegisteredSealProof
 	SectorExpiry abi.ChainEpoch
 	DealIDs      []abi.DealID
@@ -45,9 +46,9 @@ type VerifyDealsForActivationReturn struct {
 	UnsealedCIDs []*cid.Cid
 }
 
-type ActivateDealsParams struct {
-	DealIDs      []abi.DealID
-	SectorExpiry abi.ChainEpoch
+type BatchActivateDealsParams struct {
+	Sectors    []SectorDeals
+	ComputeCid bool
 }
 
 type ActivateDealsResult struct {

--- a/builtin/v13/market/methods.go
+++ b/builtin/v13/market/methods.go
@@ -16,7 +16,7 @@ var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	4: builtin.NewMethodMeta("PublishStorageDeals", *new(func(*PublishStorageDealsParams) *PublishStorageDealsReturn)), // PublishStorageDeals
 	builtin.MustGenerateFRCMethodNum("PublishStorageDeals"): builtin.NewMethodMeta("PublishStorageDealsExported", *new(func(*PublishStorageDealsParams) *PublishStorageDealsReturn)), // PublishStorageDealsExported
 	5: builtin.NewMethodMeta("VerifyDealsForActivation", *new(func(*VerifyDealsForActivationParams) *VerifyDealsForActivationReturn)), // VerifyDealsForActivation
-	6: builtin.NewMethodMeta("BatchActivateDeals", *new(func(*BatchActivateDealsParams) *abi.EmptyValue)),                                       // BatchActivateDeals
+	6: builtin.NewMethodMeta("BatchActivateDeals", *new(func(*BatchActivateDealsParams) *abi.EmptyValue)),                             // BatchActivateDeals
 	7: builtin.NewMethodMeta("OnMinerSectorsTerminate", *new(func(*OnMinerSectorsTerminateParams) *abi.EmptyValue)),                   // OnMinerSectorsTerminate
 	8: builtin.NewMethodMeta("ComputeDataCommitment", nil),                                                                            // deprecated
 	9: builtin.NewMethodMeta("CronTick", *new(func(*abi.EmptyValue) *abi.EmptyValue)),                                                 // CronTick

--- a/builtin/v13/market/methods.go
+++ b/builtin/v13/market/methods.go
@@ -16,7 +16,7 @@ var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	4: builtin.NewMethodMeta("PublishStorageDeals", *new(func(*PublishStorageDealsParams) *PublishStorageDealsReturn)), // PublishStorageDeals
 	builtin.MustGenerateFRCMethodNum("PublishStorageDeals"): builtin.NewMethodMeta("PublishStorageDealsExported", *new(func(*PublishStorageDealsParams) *PublishStorageDealsReturn)), // PublishStorageDealsExported
 	5: builtin.NewMethodMeta("VerifyDealsForActivation", *new(func(*VerifyDealsForActivationParams) *VerifyDealsForActivationReturn)), // VerifyDealsForActivation
-	6: builtin.NewMethodMeta("ActivateDeals", *new(func(*ActivateDealsParams) *abi.EmptyValue)),                                       // ActivateDeals
+	6: builtin.NewMethodMeta("BatchActivateDeals", *new(func(*BatchActivateDealsParams) *abi.EmptyValue)),                                       // BatchActivateDeals
 	7: builtin.NewMethodMeta("OnMinerSectorsTerminate", *new(func(*OnMinerSectorsTerminateParams) *abi.EmptyValue)),                   // OnMinerSectorsTerminate
 	8: builtin.NewMethodMeta("ComputeDataCommitment", nil),                                                                            // deprecated
 	9: builtin.NewMethodMeta("CronTick", *new(func(*abi.EmptyValue) *abi.EmptyValue)),                                                 // CronTick

--- a/builtin/v14/gen/gen.go
+++ b/builtin/v14/gen/gen.go
@@ -118,7 +118,7 @@ func main() {
 		market.WithdrawBalanceParams{},
 		market.PublishStorageDealsParams{},
 		market.PublishStorageDealsReturn{},
-		market.ActivateDealsParams{},
+		market.BatchActivateDealsParams{},
 		market.ActivateDealsResult{},
 		market.VerifyDealsForActivationParams{},
 		market.VerifyDealsForActivationReturn{},

--- a/builtin/v14/market/cbor_gen.go
+++ b/builtin/v14/market/cbor_gen.go
@@ -831,9 +831,9 @@ func (t *PublishStorageDealsReturn) UnmarshalCBOR(r io.Reader) (err error) {
 	return nil
 }
 
-var lengthBufActivateDealsParams = []byte{130}
+var lengthBufBatchActivateDealsParams = []byte{130}
 
-func (t *ActivateDealsParams) MarshalCBOR(w io.Writer) error {
+func (t *BatchActivateDealsParams) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
@@ -841,42 +841,34 @@ func (t *ActivateDealsParams) MarshalCBOR(w io.Writer) error {
 
 	cw := cbg.NewCborWriter(w)
 
-	if _, err := cw.Write(lengthBufActivateDealsParams); err != nil {
+	if _, err := cw.Write(lengthBufBatchActivateDealsParams); err != nil {
 		return err
 	}
 
-	// t.DealIDs ([]abi.DealID) (slice)
-	if len(t.DealIDs) > 8192 {
-		return xerrors.Errorf("Slice value in field t.DealIDs was too long")
+	// t.Sectors ([]market.SectorDeals) (slice)
+	if len(t.Sectors) > 8192 {
+		return xerrors.Errorf("Slice value in field t.Sectors was too long")
 	}
 
-	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.DealIDs))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Sectors))); err != nil {
 		return err
 	}
-	for _, v := range t.DealIDs {
-
-		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(v)); err != nil {
+	for _, v := range t.Sectors {
+		if err := v.MarshalCBOR(cw); err != nil {
 			return err
 		}
 
 	}
 
-	// t.SectorExpiry (abi.ChainEpoch) (int64)
-	if t.SectorExpiry >= 0 {
-		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.SectorExpiry)); err != nil {
-			return err
-		}
-	} else {
-		if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-t.SectorExpiry-1)); err != nil {
-			return err
-		}
+	// t.ComputeCid (bool) (bool)
+	if err := cbg.WriteBool(w, t.ComputeCid); err != nil {
+		return err
 	}
-
 	return nil
 }
 
-func (t *ActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
-	*t = ActivateDealsParams{}
+func (t *BatchActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = BatchActivateDealsParams{}
 
 	cr := cbg.NewCborReader(r)
 
@@ -898,7 +890,7 @@ func (t *ActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.DealIDs ([]abi.DealID) (slice)
+	// t.Sectors ([]market.SectorDeals) (slice)
 
 	maj, extra, err = cr.ReadHeader()
 	if err != nil {
@@ -906,7 +898,7 @@ func (t *ActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 
 	if extra > 8192 {
-		return fmt.Errorf("t.DealIDs: array too large (%d)", extra)
+		return fmt.Errorf("t.Sectors: array too large (%d)", extra)
 	}
 
 	if maj != cbg.MajArray {
@@ -914,7 +906,7 @@ func (t *ActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 
 	if extra > 0 {
-		t.DealIDs = make([]abi.DealID, extra)
+		t.Sectors = make([]SectorDeals, extra)
 	}
 
 	for i := 0; i < int(extra); i++ {
@@ -928,43 +920,30 @@ func (t *ActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
 
 			{
 
-				maj, extra, err = cr.ReadHeader()
-				if err != nil {
-					return err
+				if err := t.Sectors[i].UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Sectors[i]: %w", err)
 				}
-				if maj != cbg.MajUnsignedInt {
-					return fmt.Errorf("wrong type for uint64 field")
-				}
-				t.DealIDs[i] = abi.DealID(extra)
 
 			}
 
 		}
 	}
-	// t.SectorExpiry (abi.ChainEpoch) (int64)
-	{
-		maj, extra, err := cr.ReadHeader()
-		if err != nil {
-			return err
-		}
-		var extraI int64
-		switch maj {
-		case cbg.MajUnsignedInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 positive overflow")
-			}
-		case cbg.MajNegativeInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 negative overflow")
-			}
-			extraI = -1 - extraI
-		default:
-			return fmt.Errorf("wrong type for int64 field: %d", maj)
-		}
+	// t.ComputeCid (bool) (bool)
 
-		t.SectorExpiry = abi.ChainEpoch(extraI)
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajOther {
+		return fmt.Errorf("booleans must be major type 7")
+	}
+	switch extra {
+	case 20:
+		t.ComputeCid = false
+	case 21:
+		t.ComputeCid = true
+	default:
+		return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
 	}
 	return nil
 }
@@ -2243,7 +2222,7 @@ func (t *ClientDealProposal) UnmarshalCBOR(r io.Reader) (err error) {
 	return nil
 }
 
-var lengthBufSectorDeals = []byte{131}
+var lengthBufSectorDeals = []byte{132}
 
 func (t *SectorDeals) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -2254,6 +2233,12 @@ func (t *SectorDeals) MarshalCBOR(w io.Writer) error {
 	cw := cbg.NewCborWriter(w)
 
 	if _, err := cw.Write(lengthBufSectorDeals); err != nil {
+		return err
+	}
+
+	// t.SectorNumber (abi.SectorNumber) (uint64)
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.SectorNumber)); err != nil {
 		return err
 	}
 
@@ -2316,10 +2301,24 @@ func (t *SectorDeals) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 3 {
+	if extra != 4 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
+	// t.SectorNumber (abi.SectorNumber) (uint64)
+
+	{
+
+		maj, extra, err = cr.ReadHeader()
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.SectorNumber = abi.SectorNumber(extra)
+
+	}
 	// t.SectorType (abi.RegisteredSealProof) (int64)
 	{
 		maj, extra, err := cr.ReadHeader()

--- a/builtin/v14/market/market_types.go
+++ b/builtin/v14/market/market_types.go
@@ -35,6 +35,7 @@ type VerifyDealsForActivationParams struct {
 }
 
 type SectorDeals struct {
+	SectorNumber abi.SectorNumber
 	SectorType   abi.RegisteredSealProof
 	SectorExpiry abi.ChainEpoch
 	DealIDs      []abi.DealID
@@ -45,9 +46,9 @@ type VerifyDealsForActivationReturn struct {
 	UnsealedCIDs []*cid.Cid
 }
 
-type ActivateDealsParams struct {
-	DealIDs      []abi.DealID
-	SectorExpiry abi.ChainEpoch
+type BatchActivateDealsParams struct {
+	Sectors    []SectorDeals
+	ComputeCid bool
 }
 
 type ActivateDealsResult struct {

--- a/builtin/v14/market/methods.go
+++ b/builtin/v14/market/methods.go
@@ -16,7 +16,7 @@ var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	4: builtin.NewMethodMeta("PublishStorageDeals", *new(func(*PublishStorageDealsParams) *PublishStorageDealsReturn)), // PublishStorageDeals
 	builtin.MustGenerateFRCMethodNum("PublishStorageDeals"): builtin.NewMethodMeta("PublishStorageDealsExported", *new(func(*PublishStorageDealsParams) *PublishStorageDealsReturn)), // PublishStorageDealsExported
 	5: builtin.NewMethodMeta("VerifyDealsForActivation", *new(func(*VerifyDealsForActivationParams) *VerifyDealsForActivationReturn)), // VerifyDealsForActivation
-	6: builtin.NewMethodMeta("BatchActivateDeals", *new(func(*BatchActivateDealsParams) *abi.EmptyValue)),                                       // BatchActivateDeals
+	6: builtin.NewMethodMeta("BatchActivateDeals", *new(func(*BatchActivateDealsParams) *abi.EmptyValue)),                             // BatchActivateDeals
 	7: builtin.NewMethodMeta("OnMinerSectorsTerminate", *new(func(*OnMinerSectorsTerminateParams) *abi.EmptyValue)),                   // OnMinerSectorsTerminate
 	8: builtin.NewMethodMeta("ComputeDataCommitment", nil),                                                                            // deprecated
 	9: builtin.NewMethodMeta("CronTick", *new(func(*abi.EmptyValue) *abi.EmptyValue)),                                                 // CronTick

--- a/builtin/v14/market/methods.go
+++ b/builtin/v14/market/methods.go
@@ -16,7 +16,7 @@ var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	4: builtin.NewMethodMeta("PublishStorageDeals", *new(func(*PublishStorageDealsParams) *PublishStorageDealsReturn)), // PublishStorageDeals
 	builtin.MustGenerateFRCMethodNum("PublishStorageDeals"): builtin.NewMethodMeta("PublishStorageDealsExported", *new(func(*PublishStorageDealsParams) *PublishStorageDealsReturn)), // PublishStorageDealsExported
 	5: builtin.NewMethodMeta("VerifyDealsForActivation", *new(func(*VerifyDealsForActivationParams) *VerifyDealsForActivationReturn)), // VerifyDealsForActivation
-	6: builtin.NewMethodMeta("ActivateDeals", *new(func(*ActivateDealsParams) *abi.EmptyValue)),                                       // ActivateDeals
+	6: builtin.NewMethodMeta("BatchActivateDeals", *new(func(*BatchActivateDealsParams) *abi.EmptyValue)),                                       // BatchActivateDeals
 	7: builtin.NewMethodMeta("OnMinerSectorsTerminate", *new(func(*OnMinerSectorsTerminateParams) *abi.EmptyValue)),                   // OnMinerSectorsTerminate
 	8: builtin.NewMethodMeta("ComputeDataCommitment", nil),                                                                            // deprecated
 	9: builtin.NewMethodMeta("CronTick", *new(func(*abi.EmptyValue) *abi.EmptyValue)),                                                 // CronTick

--- a/builtin/v15/gen/gen.go
+++ b/builtin/v15/gen/gen.go
@@ -118,7 +118,7 @@ func main() {
 		market.WithdrawBalanceParams{},
 		market.PublishStorageDealsParams{},
 		market.PublishStorageDealsReturn{},
-		market.ActivateDealsParams{},
+		market.BatchActivateDealsParams{},
 		market.ActivateDealsResult{},
 		market.VerifyDealsForActivationParams{},
 		market.VerifyDealsForActivationReturn{},

--- a/builtin/v15/market/cbor_gen.go
+++ b/builtin/v15/market/cbor_gen.go
@@ -831,9 +831,9 @@ func (t *PublishStorageDealsReturn) UnmarshalCBOR(r io.Reader) (err error) {
 	return nil
 }
 
-var lengthBufActivateDealsParams = []byte{130}
+var lengthBufBatchActivateDealsParams = []byte{130}
 
-func (t *ActivateDealsParams) MarshalCBOR(w io.Writer) error {
+func (t *BatchActivateDealsParams) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
@@ -841,42 +841,34 @@ func (t *ActivateDealsParams) MarshalCBOR(w io.Writer) error {
 
 	cw := cbg.NewCborWriter(w)
 
-	if _, err := cw.Write(lengthBufActivateDealsParams); err != nil {
+	if _, err := cw.Write(lengthBufBatchActivateDealsParams); err != nil {
 		return err
 	}
 
-	// t.DealIDs ([]abi.DealID) (slice)
-	if len(t.DealIDs) > 8192 {
-		return xerrors.Errorf("Slice value in field t.DealIDs was too long")
+	// t.Sectors ([]market.SectorDeals) (slice)
+	if len(t.Sectors) > 8192 {
+		return xerrors.Errorf("Slice value in field t.Sectors was too long")
 	}
 
-	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.DealIDs))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Sectors))); err != nil {
 		return err
 	}
-	for _, v := range t.DealIDs {
-
-		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(v)); err != nil {
+	for _, v := range t.Sectors {
+		if err := v.MarshalCBOR(cw); err != nil {
 			return err
 		}
 
 	}
 
-	// t.SectorExpiry (abi.ChainEpoch) (int64)
-	if t.SectorExpiry >= 0 {
-		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.SectorExpiry)); err != nil {
-			return err
-		}
-	} else {
-		if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-t.SectorExpiry-1)); err != nil {
-			return err
-		}
+	// t.ComputeCid (bool) (bool)
+	if err := cbg.WriteBool(w, t.ComputeCid); err != nil {
+		return err
 	}
-
 	return nil
 }
 
-func (t *ActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
-	*t = ActivateDealsParams{}
+func (t *BatchActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = BatchActivateDealsParams{}
 
 	cr := cbg.NewCborReader(r)
 
@@ -898,7 +890,7 @@ func (t *ActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.DealIDs ([]abi.DealID) (slice)
+	// t.Sectors ([]market.SectorDeals) (slice)
 
 	maj, extra, err = cr.ReadHeader()
 	if err != nil {
@@ -906,7 +898,7 @@ func (t *ActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 
 	if extra > 8192 {
-		return fmt.Errorf("t.DealIDs: array too large (%d)", extra)
+		return fmt.Errorf("t.Sectors: array too large (%d)", extra)
 	}
 
 	if maj != cbg.MajArray {
@@ -914,7 +906,7 @@ func (t *ActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 
 	if extra > 0 {
-		t.DealIDs = make([]abi.DealID, extra)
+		t.Sectors = make([]SectorDeals, extra)
 	}
 
 	for i := 0; i < int(extra); i++ {
@@ -928,43 +920,30 @@ func (t *ActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
 
 			{
 
-				maj, extra, err = cr.ReadHeader()
-				if err != nil {
-					return err
+				if err := t.Sectors[i].UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Sectors[i]: %w", err)
 				}
-				if maj != cbg.MajUnsignedInt {
-					return fmt.Errorf("wrong type for uint64 field")
-				}
-				t.DealIDs[i] = abi.DealID(extra)
 
 			}
 
 		}
 	}
-	// t.SectorExpiry (abi.ChainEpoch) (int64)
-	{
-		maj, extra, err := cr.ReadHeader()
-		if err != nil {
-			return err
-		}
-		var extraI int64
-		switch maj {
-		case cbg.MajUnsignedInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 positive overflow")
-			}
-		case cbg.MajNegativeInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 negative overflow")
-			}
-			extraI = -1 - extraI
-		default:
-			return fmt.Errorf("wrong type for int64 field: %d", maj)
-		}
+	// t.ComputeCid (bool) (bool)
 
-		t.SectorExpiry = abi.ChainEpoch(extraI)
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajOther {
+		return fmt.Errorf("booleans must be major type 7")
+	}
+	switch extra {
+	case 20:
+		t.ComputeCid = false
+	case 21:
+		t.ComputeCid = true
+	default:
+		return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
 	}
 	return nil
 }
@@ -2243,7 +2222,7 @@ func (t *ClientDealProposal) UnmarshalCBOR(r io.Reader) (err error) {
 	return nil
 }
 
-var lengthBufSectorDeals = []byte{131}
+var lengthBufSectorDeals = []byte{132}
 
 func (t *SectorDeals) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -2254,6 +2233,12 @@ func (t *SectorDeals) MarshalCBOR(w io.Writer) error {
 	cw := cbg.NewCborWriter(w)
 
 	if _, err := cw.Write(lengthBufSectorDeals); err != nil {
+		return err
+	}
+
+	// t.SectorNumber (abi.SectorNumber) (uint64)
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.SectorNumber)); err != nil {
 		return err
 	}
 
@@ -2316,10 +2301,24 @@ func (t *SectorDeals) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 3 {
+	if extra != 4 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
+	// t.SectorNumber (abi.SectorNumber) (uint64)
+
+	{
+
+		maj, extra, err = cr.ReadHeader()
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.SectorNumber = abi.SectorNumber(extra)
+
+	}
 	// t.SectorType (abi.RegisteredSealProof) (int64)
 	{
 		maj, extra, err := cr.ReadHeader()

--- a/builtin/v15/market/market_types.go
+++ b/builtin/v15/market/market_types.go
@@ -35,6 +35,7 @@ type VerifyDealsForActivationParams struct {
 }
 
 type SectorDeals struct {
+	SectorNumber abi.SectorNumber
 	SectorType   abi.RegisteredSealProof
 	SectorExpiry abi.ChainEpoch
 	DealIDs      []abi.DealID
@@ -45,9 +46,9 @@ type VerifyDealsForActivationReturn struct {
 	UnsealedCIDs []*cid.Cid
 }
 
-type ActivateDealsParams struct {
-	DealIDs      []abi.DealID
-	SectorExpiry abi.ChainEpoch
+type BatchActivateDealsParams struct {
+	Sectors    []SectorDeals
+	ComputeCid bool
 }
 
 type ActivateDealsResult struct {

--- a/builtin/v15/market/methods.go
+++ b/builtin/v15/market/methods.go
@@ -16,7 +16,7 @@ var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	4: builtin.NewMethodMeta("PublishStorageDeals", *new(func(*PublishStorageDealsParams) *PublishStorageDealsReturn)), // PublishStorageDeals
 	builtin.MustGenerateFRCMethodNum("PublishStorageDeals"): builtin.NewMethodMeta("PublishStorageDealsExported", *new(func(*PublishStorageDealsParams) *PublishStorageDealsReturn)), // PublishStorageDealsExported
 	5: builtin.NewMethodMeta("VerifyDealsForActivation", *new(func(*VerifyDealsForActivationParams) *VerifyDealsForActivationReturn)), // VerifyDealsForActivation
-	6: builtin.NewMethodMeta("BatchActivateDeals", *new(func(*BatchActivateDealsParams) *abi.EmptyValue)),                                       // BatchActivateDeals
+	6: builtin.NewMethodMeta("BatchActivateDeals", *new(func(*BatchActivateDealsParams) *abi.EmptyValue)),                             // BatchActivateDeals
 	7: builtin.NewMethodMeta("OnMinerSectorsTerminate", *new(func(*OnMinerSectorsTerminateParams) *abi.EmptyValue)),                   // OnMinerSectorsTerminate
 	8: builtin.NewMethodMeta("ComputeDataCommitment", nil),                                                                            // deprecated
 	9: builtin.NewMethodMeta("CronTick", *new(func(*abi.EmptyValue) *abi.EmptyValue)),                                                 // CronTick

--- a/builtin/v15/market/methods.go
+++ b/builtin/v15/market/methods.go
@@ -16,7 +16,7 @@ var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	4: builtin.NewMethodMeta("PublishStorageDeals", *new(func(*PublishStorageDealsParams) *PublishStorageDealsReturn)), // PublishStorageDeals
 	builtin.MustGenerateFRCMethodNum("PublishStorageDeals"): builtin.NewMethodMeta("PublishStorageDealsExported", *new(func(*PublishStorageDealsParams) *PublishStorageDealsReturn)), // PublishStorageDealsExported
 	5: builtin.NewMethodMeta("VerifyDealsForActivation", *new(func(*VerifyDealsForActivationParams) *VerifyDealsForActivationReturn)), // VerifyDealsForActivation
-	6: builtin.NewMethodMeta("ActivateDeals", *new(func(*ActivateDealsParams) *abi.EmptyValue)),                                       // ActivateDeals
+	6: builtin.NewMethodMeta("BatchActivateDeals", *new(func(*BatchActivateDealsParams) *abi.EmptyValue)),                                       // BatchActivateDeals
 	7: builtin.NewMethodMeta("OnMinerSectorsTerminate", *new(func(*OnMinerSectorsTerminateParams) *abi.EmptyValue)),                   // OnMinerSectorsTerminate
 	8: builtin.NewMethodMeta("ComputeDataCommitment", nil),                                                                            // deprecated
 	9: builtin.NewMethodMeta("CronTick", *new(func(*abi.EmptyValue) *abi.EmptyValue)),                                                 // CronTick

--- a/builtin/v16/gen/gen.go
+++ b/builtin/v16/gen/gen.go
@@ -119,7 +119,7 @@ func main() {
 		market.WithdrawBalanceParams{},
 		market.PublishStorageDealsParams{},
 		market.PublishStorageDealsReturn{},
-		market.ActivateDealsParams{},
+		market.BatchActivateDealsParams{},
 		market.ActivateDealsResult{},
 		market.VerifyDealsForActivationParams{},
 		market.VerifyDealsForActivationReturn{},

--- a/builtin/v16/market/cbor_gen.go
+++ b/builtin/v16/market/cbor_gen.go
@@ -831,9 +831,9 @@ func (t *PublishStorageDealsReturn) UnmarshalCBOR(r io.Reader) (err error) {
 	return nil
 }
 
-var lengthBufActivateDealsParams = []byte{130}
+var lengthBufBatchActivateDealsParams = []byte{130}
 
-func (t *ActivateDealsParams) MarshalCBOR(w io.Writer) error {
+func (t *BatchActivateDealsParams) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
@@ -841,42 +841,34 @@ func (t *ActivateDealsParams) MarshalCBOR(w io.Writer) error {
 
 	cw := cbg.NewCborWriter(w)
 
-	if _, err := cw.Write(lengthBufActivateDealsParams); err != nil {
+	if _, err := cw.Write(lengthBufBatchActivateDealsParams); err != nil {
 		return err
 	}
 
-	// t.DealIDs ([]abi.DealID) (slice)
-	if len(t.DealIDs) > 8192 {
-		return xerrors.Errorf("Slice value in field t.DealIDs was too long")
+	// t.Sectors ([]market.SectorDeals) (slice)
+	if len(t.Sectors) > 8192 {
+		return xerrors.Errorf("Slice value in field t.Sectors was too long")
 	}
 
-	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.DealIDs))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Sectors))); err != nil {
 		return err
 	}
-	for _, v := range t.DealIDs {
-
-		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(v)); err != nil {
+	for _, v := range t.Sectors {
+		if err := v.MarshalCBOR(cw); err != nil {
 			return err
 		}
 
 	}
 
-	// t.SectorExpiry (abi.ChainEpoch) (int64)
-	if t.SectorExpiry >= 0 {
-		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.SectorExpiry)); err != nil {
-			return err
-		}
-	} else {
-		if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-t.SectorExpiry-1)); err != nil {
-			return err
-		}
+	// t.ComputeCid (bool) (bool)
+	if err := cbg.WriteBool(w, t.ComputeCid); err != nil {
+		return err
 	}
-
 	return nil
 }
 
-func (t *ActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
-	*t = ActivateDealsParams{}
+func (t *BatchActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = BatchActivateDealsParams{}
 
 	cr := cbg.NewCborReader(r)
 
@@ -898,7 +890,7 @@ func (t *ActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.DealIDs ([]abi.DealID) (slice)
+	// t.Sectors ([]market.SectorDeals) (slice)
 
 	maj, extra, err = cr.ReadHeader()
 	if err != nil {
@@ -906,7 +898,7 @@ func (t *ActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 
 	if extra > 8192 {
-		return fmt.Errorf("t.DealIDs: array too large (%d)", extra)
+		return fmt.Errorf("t.Sectors: array too large (%d)", extra)
 	}
 
 	if maj != cbg.MajArray {
@@ -914,7 +906,7 @@ func (t *ActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 
 	if extra > 0 {
-		t.DealIDs = make([]abi.DealID, extra)
+		t.Sectors = make([]SectorDeals, extra)
 	}
 
 	for i := 0; i < int(extra); i++ {
@@ -928,43 +920,30 @@ func (t *ActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
 
 			{
 
-				maj, extra, err = cr.ReadHeader()
-				if err != nil {
-					return err
+				if err := t.Sectors[i].UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Sectors[i]: %w", err)
 				}
-				if maj != cbg.MajUnsignedInt {
-					return fmt.Errorf("wrong type for uint64 field")
-				}
-				t.DealIDs[i] = abi.DealID(extra)
 
 			}
 
 		}
 	}
-	// t.SectorExpiry (abi.ChainEpoch) (int64)
-	{
-		maj, extra, err := cr.ReadHeader()
-		if err != nil {
-			return err
-		}
-		var extraI int64
-		switch maj {
-		case cbg.MajUnsignedInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 positive overflow")
-			}
-		case cbg.MajNegativeInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 negative overflow")
-			}
-			extraI = -1 - extraI
-		default:
-			return fmt.Errorf("wrong type for int64 field: %d", maj)
-		}
+	// t.ComputeCid (bool) (bool)
 
-		t.SectorExpiry = abi.ChainEpoch(extraI)
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajOther {
+		return fmt.Errorf("booleans must be major type 7")
+	}
+	switch extra {
+	case 20:
+		t.ComputeCid = false
+	case 21:
+		t.ComputeCid = true
+	default:
+		return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
 	}
 	return nil
 }
@@ -2243,7 +2222,7 @@ func (t *ClientDealProposal) UnmarshalCBOR(r io.Reader) (err error) {
 	return nil
 }
 
-var lengthBufSectorDeals = []byte{131}
+var lengthBufSectorDeals = []byte{132}
 
 func (t *SectorDeals) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -2254,6 +2233,12 @@ func (t *SectorDeals) MarshalCBOR(w io.Writer) error {
 	cw := cbg.NewCborWriter(w)
 
 	if _, err := cw.Write(lengthBufSectorDeals); err != nil {
+		return err
+	}
+
+	// t.SectorNumber (abi.SectorNumber) (uint64)
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.SectorNumber)); err != nil {
 		return err
 	}
 
@@ -2316,10 +2301,24 @@ func (t *SectorDeals) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 3 {
+	if extra != 4 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
+	// t.SectorNumber (abi.SectorNumber) (uint64)
+
+	{
+
+		maj, extra, err = cr.ReadHeader()
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.SectorNumber = abi.SectorNumber(extra)
+
+	}
 	// t.SectorType (abi.RegisteredSealProof) (int64)
 	{
 		maj, extra, err := cr.ReadHeader()

--- a/builtin/v16/market/market_types.go
+++ b/builtin/v16/market/market_types.go
@@ -35,6 +35,7 @@ type VerifyDealsForActivationParams struct {
 }
 
 type SectorDeals struct {
+	SectorNumber abi.SectorNumber
 	SectorType   abi.RegisteredSealProof
 	SectorExpiry abi.ChainEpoch
 	DealIDs      []abi.DealID
@@ -45,9 +46,9 @@ type VerifyDealsForActivationReturn struct {
 	UnsealedCIDs []*cid.Cid
 }
 
-type ActivateDealsParams struct {
-	DealIDs      []abi.DealID
-	SectorExpiry abi.ChainEpoch
+type BatchActivateDealsParams struct {
+	Sectors    []SectorDeals
+	ComputeCid bool
 }
 
 type ActivateDealsResult struct {

--- a/builtin/v16/market/methods.go
+++ b/builtin/v16/market/methods.go
@@ -16,7 +16,7 @@ var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	4: builtin.NewMethodMeta("PublishStorageDeals", *new(func(*PublishStorageDealsParams) *PublishStorageDealsReturn)), // PublishStorageDeals
 	builtin.MustGenerateFRCMethodNum("PublishStorageDeals"): builtin.NewMethodMeta("PublishStorageDealsExported", *new(func(*PublishStorageDealsParams) *PublishStorageDealsReturn)), // PublishStorageDealsExported
 	5: builtin.NewMethodMeta("VerifyDealsForActivation", *new(func(*VerifyDealsForActivationParams) *VerifyDealsForActivationReturn)), // VerifyDealsForActivation
-	6: builtin.NewMethodMeta("BatchActivateDeals", *new(func(*BatchActivateDealsParams) *abi.EmptyValue)),                                       // BatchActivateDeals
+	6: builtin.NewMethodMeta("BatchActivateDeals", *new(func(*BatchActivateDealsParams) *abi.EmptyValue)),                             // BatchActivateDeals
 	7: builtin.NewMethodMeta("OnMinerSectorsTerminate", *new(func(*OnMinerSectorsTerminateParams) *abi.EmptyValue)),                   // OnMinerSectorsTerminate
 	8: builtin.NewMethodMeta("ComputeDataCommitment", nil),                                                                            // deprecated
 	9: builtin.NewMethodMeta("CronTick", *new(func(*abi.EmptyValue) *abi.EmptyValue)),                                                 // CronTick

--- a/builtin/v16/market/methods.go
+++ b/builtin/v16/market/methods.go
@@ -16,7 +16,7 @@ var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	4: builtin.NewMethodMeta("PublishStorageDeals", *new(func(*PublishStorageDealsParams) *PublishStorageDealsReturn)), // PublishStorageDeals
 	builtin.MustGenerateFRCMethodNum("PublishStorageDeals"): builtin.NewMethodMeta("PublishStorageDealsExported", *new(func(*PublishStorageDealsParams) *PublishStorageDealsReturn)), // PublishStorageDealsExported
 	5: builtin.NewMethodMeta("VerifyDealsForActivation", *new(func(*VerifyDealsForActivationParams) *VerifyDealsForActivationReturn)), // VerifyDealsForActivation
-	6: builtin.NewMethodMeta("ActivateDeals", *new(func(*ActivateDealsParams) *abi.EmptyValue)),                                       // ActivateDeals
+	6: builtin.NewMethodMeta("BatchActivateDeals", *new(func(*BatchActivateDealsParams) *abi.EmptyValue)),                                       // BatchActivateDeals
 	7: builtin.NewMethodMeta("OnMinerSectorsTerminate", *new(func(*OnMinerSectorsTerminateParams) *abi.EmptyValue)),                   // OnMinerSectorsTerminate
 	8: builtin.NewMethodMeta("ComputeDataCommitment", nil),                                                                            // deprecated
 	9: builtin.NewMethodMeta("CronTick", *new(func(*abi.EmptyValue) *abi.EmptyValue)),                                                 // CronTick

--- a/builtin/v17/gen/gen.go
+++ b/builtin/v17/gen/gen.go
@@ -119,7 +119,7 @@ func main() {
 		market.WithdrawBalanceParams{},
 		market.PublishStorageDealsParams{},
 		market.PublishStorageDealsReturn{},
-		market.ActivateDealsParams{},
+		market.BatchActivateDealsParams{},
 		market.ActivateDealsResult{},
 		market.VerifyDealsForActivationParams{},
 		market.VerifyDealsForActivationReturn{},

--- a/builtin/v17/market/cbor_gen.go
+++ b/builtin/v17/market/cbor_gen.go
@@ -831,9 +831,9 @@ func (t *PublishStorageDealsReturn) UnmarshalCBOR(r io.Reader) (err error) {
 	return nil
 }
 
-var lengthBufActivateDealsParams = []byte{130}
+var lengthBufBatchActivateDealsParams = []byte{130}
 
-func (t *ActivateDealsParams) MarshalCBOR(w io.Writer) error {
+func (t *BatchActivateDealsParams) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
@@ -841,42 +841,34 @@ func (t *ActivateDealsParams) MarshalCBOR(w io.Writer) error {
 
 	cw := cbg.NewCborWriter(w)
 
-	if _, err := cw.Write(lengthBufActivateDealsParams); err != nil {
+	if _, err := cw.Write(lengthBufBatchActivateDealsParams); err != nil {
 		return err
 	}
 
-	// t.DealIDs ([]abi.DealID) (slice)
-	if len(t.DealIDs) > 8192 {
-		return xerrors.Errorf("Slice value in field t.DealIDs was too long")
+	// t.Sectors ([]market.SectorDeals) (slice)
+	if len(t.Sectors) > 8192 {
+		return xerrors.Errorf("Slice value in field t.Sectors was too long")
 	}
 
-	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.DealIDs))); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Sectors))); err != nil {
 		return err
 	}
-	for _, v := range t.DealIDs {
-
-		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(v)); err != nil {
+	for _, v := range t.Sectors {
+		if err := v.MarshalCBOR(cw); err != nil {
 			return err
 		}
 
 	}
 
-	// t.SectorExpiry (abi.ChainEpoch) (int64)
-	if t.SectorExpiry >= 0 {
-		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.SectorExpiry)); err != nil {
-			return err
-		}
-	} else {
-		if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-t.SectorExpiry-1)); err != nil {
-			return err
-		}
+	// t.ComputeCid (bool) (bool)
+	if err := cbg.WriteBool(w, t.ComputeCid); err != nil {
+		return err
 	}
-
 	return nil
 }
 
-func (t *ActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
-	*t = ActivateDealsParams{}
+func (t *BatchActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = BatchActivateDealsParams{}
 
 	cr := cbg.NewCborReader(r)
 
@@ -898,7 +890,7 @@ func (t *ActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.DealIDs ([]abi.DealID) (slice)
+	// t.Sectors ([]market.SectorDeals) (slice)
 
 	maj, extra, err = cr.ReadHeader()
 	if err != nil {
@@ -906,7 +898,7 @@ func (t *ActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 
 	if extra > 8192 {
-		return fmt.Errorf("t.DealIDs: array too large (%d)", extra)
+		return fmt.Errorf("t.Sectors: array too large (%d)", extra)
 	}
 
 	if maj != cbg.MajArray {
@@ -914,7 +906,7 @@ func (t *ActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 
 	if extra > 0 {
-		t.DealIDs = make([]abi.DealID, extra)
+		t.Sectors = make([]SectorDeals, extra)
 	}
 
 	for i := 0; i < int(extra); i++ {
@@ -928,43 +920,30 @@ func (t *ActivateDealsParams) UnmarshalCBOR(r io.Reader) (err error) {
 
 			{
 
-				maj, extra, err = cr.ReadHeader()
-				if err != nil {
-					return err
+				if err := t.Sectors[i].UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Sectors[i]: %w", err)
 				}
-				if maj != cbg.MajUnsignedInt {
-					return fmt.Errorf("wrong type for uint64 field")
-				}
-				t.DealIDs[i] = abi.DealID(extra)
 
 			}
 
 		}
 	}
-	// t.SectorExpiry (abi.ChainEpoch) (int64)
-	{
-		maj, extra, err := cr.ReadHeader()
-		if err != nil {
-			return err
-		}
-		var extraI int64
-		switch maj {
-		case cbg.MajUnsignedInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 positive overflow")
-			}
-		case cbg.MajNegativeInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 negative overflow")
-			}
-			extraI = -1 - extraI
-		default:
-			return fmt.Errorf("wrong type for int64 field: %d", maj)
-		}
+	// t.ComputeCid (bool) (bool)
 
-		t.SectorExpiry = abi.ChainEpoch(extraI)
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajOther {
+		return fmt.Errorf("booleans must be major type 7")
+	}
+	switch extra {
+	case 20:
+		t.ComputeCid = false
+	case 21:
+		t.ComputeCid = true
+	default:
+		return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
 	}
 	return nil
 }
@@ -2243,7 +2222,7 @@ func (t *ClientDealProposal) UnmarshalCBOR(r io.Reader) (err error) {
 	return nil
 }
 
-var lengthBufSectorDeals = []byte{131}
+var lengthBufSectorDeals = []byte{132}
 
 func (t *SectorDeals) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -2254,6 +2233,12 @@ func (t *SectorDeals) MarshalCBOR(w io.Writer) error {
 	cw := cbg.NewCborWriter(w)
 
 	if _, err := cw.Write(lengthBufSectorDeals); err != nil {
+		return err
+	}
+
+	// t.SectorNumber (abi.SectorNumber) (uint64)
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.SectorNumber)); err != nil {
 		return err
 	}
 
@@ -2316,10 +2301,24 @@ func (t *SectorDeals) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 3 {
+	if extra != 4 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
+	// t.SectorNumber (abi.SectorNumber) (uint64)
+
+	{
+
+		maj, extra, err = cr.ReadHeader()
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.SectorNumber = abi.SectorNumber(extra)
+
+	}
 	// t.SectorType (abi.RegisteredSealProof) (int64)
 	{
 		maj, extra, err := cr.ReadHeader()

--- a/builtin/v17/market/market_types.go
+++ b/builtin/v17/market/market_types.go
@@ -35,6 +35,7 @@ type VerifyDealsForActivationParams struct {
 }
 
 type SectorDeals struct {
+	SectorNumber abi.SectorNumber
 	SectorType   abi.RegisteredSealProof
 	SectorExpiry abi.ChainEpoch
 	DealIDs      []abi.DealID
@@ -45,9 +46,9 @@ type VerifyDealsForActivationReturn struct {
 	UnsealedCIDs []*cid.Cid
 }
 
-type ActivateDealsParams struct {
-	DealIDs      []abi.DealID
-	SectorExpiry abi.ChainEpoch
+type BatchActivateDealsParams struct {
+	Sectors    []SectorDeals
+	ComputeCid bool
 }
 
 type ActivateDealsResult struct {

--- a/builtin/v17/market/methods.go
+++ b/builtin/v17/market/methods.go
@@ -16,7 +16,7 @@ var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	4: builtin.NewMethodMeta("PublishStorageDeals", *new(func(*PublishStorageDealsParams) *PublishStorageDealsReturn)), // PublishStorageDeals
 	builtin.MustGenerateFRCMethodNum("PublishStorageDeals"): builtin.NewMethodMeta("PublishStorageDealsExported", *new(func(*PublishStorageDealsParams) *PublishStorageDealsReturn)), // PublishStorageDealsExported
 	5: builtin.NewMethodMeta("VerifyDealsForActivation", *new(func(*VerifyDealsForActivationParams) *VerifyDealsForActivationReturn)), // VerifyDealsForActivation
-	6: builtin.NewMethodMeta("BatchActivateDeals", *new(func(*BatchActivateDealsParams) *abi.EmptyValue)),                                       // BatchActivateDeals
+	6: builtin.NewMethodMeta("BatchActivateDeals", *new(func(*BatchActivateDealsParams) *abi.EmptyValue)),                             // BatchActivateDeals
 	7: builtin.NewMethodMeta("OnMinerSectorsTerminate", *new(func(*OnMinerSectorsTerminateParams) *abi.EmptyValue)),                   // OnMinerSectorsTerminate
 	8: builtin.NewMethodMeta("ComputeDataCommitment", nil),                                                                            // deprecated
 	9: builtin.NewMethodMeta("CronTick", *new(func(*abi.EmptyValue) *abi.EmptyValue)),                                                 // CronTick

--- a/builtin/v17/market/methods.go
+++ b/builtin/v17/market/methods.go
@@ -16,7 +16,7 @@ var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	4: builtin.NewMethodMeta("PublishStorageDeals", *new(func(*PublishStorageDealsParams) *PublishStorageDealsReturn)), // PublishStorageDeals
 	builtin.MustGenerateFRCMethodNum("PublishStorageDeals"): builtin.NewMethodMeta("PublishStorageDealsExported", *new(func(*PublishStorageDealsParams) *PublishStorageDealsReturn)), // PublishStorageDealsExported
 	5: builtin.NewMethodMeta("VerifyDealsForActivation", *new(func(*VerifyDealsForActivationParams) *VerifyDealsForActivationReturn)), // VerifyDealsForActivation
-	6: builtin.NewMethodMeta("ActivateDeals", *new(func(*ActivateDealsParams) *abi.EmptyValue)),                                       // ActivateDeals
+	6: builtin.NewMethodMeta("BatchActivateDeals", *new(func(*BatchActivateDealsParams) *abi.EmptyValue)),                                       // BatchActivateDeals
 	7: builtin.NewMethodMeta("OnMinerSectorsTerminate", *new(func(*OnMinerSectorsTerminateParams) *abi.EmptyValue)),                   // OnMinerSectorsTerminate
 	8: builtin.NewMethodMeta("ComputeDataCommitment", nil),                                                                            // deprecated
 	9: builtin.NewMethodMeta("CronTick", *new(func(*abi.EmptyValue) *abi.EmptyValue)),                                                 // CronTick


### PR DESCRIPTION
Closes: #409

From builtin-actor v12 onwards, `ActivateDeals` was replaced with 
`BatchActivateDeals`, but go-state-types was still using the old method.

This change updates all affected versions (v12–latest) to align with the
current actor API.

- Method rename: ActivateDeals -> BatchActivateDeals
- Param type change: ActivateDealsParams -> BatchActivateDealsParams
- Updated parameter structure with sector-specific fields
- Regenerated CBOR for updated params