### PR TITLE
Include `v18` miner actors methods and types

### DIFF
--- a/abi/sector.go
+++ b/abi/sector.go
@@ -612,3 +612,14 @@ func (p RegisteredPoStProof) ProofSize() (uint64, error) {
 type SealRandomness Randomness
 type InteractiveSealRandomness Randomness
 type PoStRandomness Randomness
+
+type SectorStatusCode uint8
+
+const (
+	// SectorStatusCodeDead sector is not live (terminated or never committed)
+	SectorStatusCodeDead SectorStatusCode = iota
+	// SectorStatusCodeActive sector is active (not terminated, not faulty)
+	SectorStatusCodeActive
+	// SectorStatusCodeFaulty sector is currently faulty
+	SectorStatusCodeFaulty
+)

--- a/builtin/v18/gen/gen.go
+++ b/builtin/v18/gen/gen.go
@@ -80,12 +80,12 @@ func main() {
 		// actor state
 		paych.State{},
 		paych.LaneState{},
-		//method params and returns
+		// method params and returns
 		paych.ConstructorParams{},
 		paych.UpdateChannelStateParams{},
 		paych.SignedVoucher{},
 		paych.ModVerifyParams{},
-		//other types
+		// other types
 		paych.Merge{},
 	); err != nil {
 		panic(err)
@@ -220,6 +220,9 @@ func main() {
 		miner.SectorNIActivationInfo{},
 		miner.ProveCommitSectorsNIParams{},
 		miner.MaxTerminationFeeParams{},
+		miner.GenerateSectorLocationParams{},
+		miner.GenerateSectorLocationReturn{},
+		miner.ValidateSectorStatusParams{},
 	); err != nil {
 		panic(err)
 	}

--- a/builtin/v18/miner/cbor_gen.go
+++ b/builtin/v18/miner/cbor_gen.go
@@ -10069,3 +10069,278 @@ func (t *MaxTerminationFeeParams) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	return nil
 }
+
+var lengthBufGenerateSectorLocationParams = []byte{129}
+
+func (t *GenerateSectorLocationParams) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+
+	cw := cbg.NewCborWriter(w)
+
+	if _, err := cw.Write(lengthBufGenerateSectorLocationParams); err != nil {
+		return err
+	}
+
+	// t.SectorNumber (abi.SectorNumber) (uint64)
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.SectorNumber)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *GenerateSectorLocationParams) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = GenerateSectorLocationParams{}
+
+	cr := cbg.NewCborReader(r)
+
+	maj, extra, err := cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
+	}()
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 1 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.SectorNumber (abi.SectorNumber) (uint64)
+
+	{
+
+		maj, extra, err = cr.ReadHeader()
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.SectorNumber = abi.SectorNumber(extra)
+
+	}
+	return nil
+}
+
+var lengthBufGenerateSectorLocationReturn = []byte{130}
+
+func (t *GenerateSectorLocationReturn) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+
+	cw := cbg.NewCborWriter(w)
+
+	if _, err := cw.Write(lengthBufGenerateSectorLocationReturn); err != nil {
+		return err
+	}
+
+	// t.Status (abi.SectorStatusCode) (uint8)
+	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Status)); err != nil {
+		return err
+	}
+
+	// t.AuxData ([]uint8) (slice)
+	if len(t.AuxData) > 2097152 {
+		return xerrors.Errorf("Byte array in field t.AuxData was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajByteString, uint64(len(t.AuxData))); err != nil {
+		return err
+	}
+
+	if _, err := cw.Write(t.AuxData); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *GenerateSectorLocationReturn) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = GenerateSectorLocationReturn{}
+
+	cr := cbg.NewCborReader(r)
+
+	maj, extra, err := cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
+	}()
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 2 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.Status (abi.SectorStatusCode) (uint8)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajUnsignedInt {
+		return fmt.Errorf("wrong type for uint8 field")
+	}
+	if extra > math.MaxUint8 {
+		return fmt.Errorf("integer in input was too large for uint8 field")
+	}
+	t.Status = abi.SectorStatusCode(extra)
+	// t.AuxData ([]uint8) (slice)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if extra > 2097152 {
+		return fmt.Errorf("t.AuxData: byte array too large (%d)", extra)
+	}
+	if maj != cbg.MajByteString {
+		return fmt.Errorf("expected byte array")
+	}
+
+	if extra > 0 {
+		t.AuxData = make([]uint8, extra)
+	}
+
+	if _, err := io.ReadFull(cr, t.AuxData); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var lengthBufValidateSectorStatusParams = []byte{131}
+
+func (t *ValidateSectorStatusParams) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+
+	cw := cbg.NewCborWriter(w)
+
+	if _, err := cw.Write(lengthBufValidateSectorStatusParams); err != nil {
+		return err
+	}
+
+	// t.SectorNumber (abi.SectorNumber) (uint64)
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.SectorNumber)); err != nil {
+		return err
+	}
+
+	// t.Status (abi.SectorStatusCode) (uint8)
+	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Status)); err != nil {
+		return err
+	}
+
+	// t.AuxData ([]uint8) (slice)
+	if len(t.AuxData) > 2097152 {
+		return xerrors.Errorf("Byte array in field t.AuxData was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajByteString, uint64(len(t.AuxData))); err != nil {
+		return err
+	}
+
+	if _, err := cw.Write(t.AuxData); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *ValidateSectorStatusParams) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = ValidateSectorStatusParams{}
+
+	cr := cbg.NewCborReader(r)
+
+	maj, extra, err := cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
+	}()
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 3 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.SectorNumber (abi.SectorNumber) (uint64)
+
+	{
+
+		maj, extra, err = cr.ReadHeader()
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.SectorNumber = abi.SectorNumber(extra)
+
+	}
+	// t.Status (abi.SectorStatusCode) (uint8)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajUnsignedInt {
+		return fmt.Errorf("wrong type for uint8 field")
+	}
+	if extra > math.MaxUint8 {
+		return fmt.Errorf("integer in input was too large for uint8 field")
+	}
+	t.Status = abi.SectorStatusCode(extra)
+	// t.AuxData ([]uint8) (slice)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if extra > 2097152 {
+		return fmt.Errorf("t.AuxData: byte array too large (%d)", extra)
+	}
+	if maj != cbg.MajByteString {
+		return fmt.Errorf("expected byte array")
+	}
+
+	if extra > 0 {
+		t.AuxData = make([]uint8, extra)
+	}
+
+	if _, err := io.ReadFull(cr, t.AuxData); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/builtin/v18/miner/methods.go
+++ b/builtin/v18/miner/methods.go
@@ -53,15 +53,18 @@ var Methods = map[abi.MethodNum]builtin.MethodMeta{
 	builtin.MustGenerateFRCMethodNum("GetBeneficiary"): builtin.NewMethodMeta("GetBeneficiaryExported", *new(func(*abi.EmptyValue) *GetBeneficiaryReturn)), // GetBeneficiaryExported
 	// NB: the name of this method must not change across actor/network versions
 	32: builtin.NewMethodMeta("ExtendSectorExpiration2", *new(func(*ExtendSectorExpiration2Params) *abi.EmptyValue)), // ExtendSectorExpiration2
-	builtin.MustGenerateFRCMethodNum("MaxTerminationFee"):    builtin.NewMethodMeta("MaxTerminationFeeExported", *new(func(*MaxTerminationFeeParams) *MaxTerminationFeeReturn)),                 // MaxTerminationFeeExported
-	builtin.MustGenerateFRCMethodNum("InitialPledge"):        builtin.NewMethodMeta("InitialPledgeExported", *new(func(*abi.EmptyValue) *InitialPledgeReturn)),                                  // InitialPledgeExported
-	builtin.MustGenerateFRCMethodNum("GetOwner"):             builtin.NewMethodMeta("GetOwnerExported", *new(func(*abi.EmptyValue) *GetOwnerReturn)),                                            // GetOwnerExported
-	builtin.MustGenerateFRCMethodNum("IsControllingAddress"): builtin.NewMethodMeta("IsControllingAddressExported", *new(func(params *IsControllingAddressParams) *IsControllingAddressReturn)), // IsControllingAddressExported
-	builtin.MustGenerateFRCMethodNum("GetSectorSize"):        builtin.NewMethodMeta("GetSectorSizeExported", *new(func(*abi.EmptyValue) *GetSectorSizeReturn)),                                  // GetSectorSizeExported
-	builtin.MustGenerateFRCMethodNum("GetAvailableBalance"):  builtin.NewMethodMeta("GetAvailableBalanceExported", *new(func(*abi.EmptyValue) *GetAvailableBalanceReturn)),                      // GetAvailableBalanceExported
-	builtin.MustGenerateFRCMethodNum("GetVestingFunds"):      builtin.NewMethodMeta("GetVestingFundsExported", *new(func(*abi.EmptyValue) *GetVestingFundsReturn)),                              // GetVestingFundsExported
-	builtin.MustGenerateFRCMethodNum("GetPeerID"):            builtin.NewMethodMeta("GetPeerIDExported", *new(func(*abi.EmptyValue) *GetPeerIDReturn)),                                          // GetPeerIDExported
-	builtin.MustGenerateFRCMethodNum("GetMultiaddrs"):        builtin.NewMethodMeta("GetMultiaddrsExported", *new(func(*abi.EmptyValue) *GetMultiAddrsReturn)),                                  // GetMultiaddrsExported
+	builtin.MustGenerateFRCMethodNum("MaxTerminationFee"):          builtin.NewMethodMeta("MaxTerminationFeeExported", *new(func(*MaxTerminationFeeParams) *MaxTerminationFeeReturn)),                 // MaxTerminationFeeExported
+	builtin.MustGenerateFRCMethodNum("InitialPledge"):              builtin.NewMethodMeta("InitialPledgeExported", *new(func(*abi.EmptyValue) *InitialPledgeReturn)),                                  // InitialPledgeExported
+	builtin.MustGenerateFRCMethodNum("GetOwner"):                   builtin.NewMethodMeta("GetOwnerExported", *new(func(*abi.EmptyValue) *GetOwnerReturn)),                                            // GetOwnerExported
+	builtin.MustGenerateFRCMethodNum("IsControllingAddress"):       builtin.NewMethodMeta("IsControllingAddressExported", *new(func(params *IsControllingAddressParams) *IsControllingAddressReturn)), // IsControllingAddressExported
+	builtin.MustGenerateFRCMethodNum("GetSectorSize"):              builtin.NewMethodMeta("GetSectorSizeExported", *new(func(*abi.EmptyValue) *GetSectorSizeReturn)),                                  // GetSectorSizeExported
+	builtin.MustGenerateFRCMethodNum("GetAvailableBalance"):        builtin.NewMethodMeta("GetAvailableBalanceExported", *new(func(*abi.EmptyValue) *GetAvailableBalanceReturn)),                      // GetAvailableBalanceExported
+	builtin.MustGenerateFRCMethodNum("GetVestingFunds"):            builtin.NewMethodMeta("GetVestingFundsExported", *new(func(*abi.EmptyValue) *GetVestingFundsReturn)),                              // GetVestingFundsExported
+	builtin.MustGenerateFRCMethodNum("GetPeerID"):                  builtin.NewMethodMeta("GetPeerIDExported", *new(func(*abi.EmptyValue) *GetPeerIDReturn)),                                          // GetPeerIDExported
+	builtin.MustGenerateFRCMethodNum("GetMultiaddrs"):              builtin.NewMethodMeta("GetMultiaddrsExported", *new(func(*abi.EmptyValue) *GetMultiAddrsReturn)),                                  // GetMultiaddrsExported
+	builtin.MustGenerateFRCMethodNum("GenerateSectorLocation"):     builtin.NewMethodMeta("GenerateSectorLocationExported", *new(func(*GenerateSectorLocationParams) *GenerateSectorLocationReturn)),  // GenerateSectorLocationExported
+	builtin.MustGenerateFRCMethodNum("ValidateSectorStatus"):       builtin.NewMethodMeta("ValidateSectorStatusExported", *new(func(*ValidateSectorStatusParams) *ValidateSectorStatusReturn)),        // ValidateSectorStatusExported
+	builtin.MustGenerateFRCMethodNum("GetNominalSectorExpiration"): builtin.NewMethodMeta("GetNominalSectorExpirationExported", *new(func(*abi.SectorNumber) *GetNominalSectorExpirationReturn)),      // GetNominalSectorExpirationExported
 	// 33 MovePartitions
 	34: builtin.NewMethodMeta("ProveCommitSectors3", *new(func(*ProveCommitSectors3Params) *ProveCommitSectors3Return)),    // ProveCommitSectors3
 	35: builtin.NewMethodMeta("ProveReplicaUpdates3", *new(func(*ProveReplicaUpdates3Params) *ProveReplicaUpdates3Return)), // ProveReplicaUpdates3

--- a/builtin/v18/miner/miner_types.go
+++ b/builtin/v18/miner/miner_types.go
@@ -525,3 +525,22 @@ type MaxTerminationFeeParams struct {
 type MaxTerminationFeeReturn = abi.TokenAmount
 
 type InitialPledgeReturn = abi.TokenAmount
+
+type GenerateSectorLocationParams struct {
+	SectorNumber abi.SectorNumber
+}
+
+type GenerateSectorLocationReturn struct {
+	Status  abi.SectorStatusCode
+	AuxData []byte
+}
+
+type ValidateSectorStatusParams struct {
+	SectorNumber abi.SectorNumber
+	Status       abi.SectorStatusCode
+	AuxData      []byte
+}
+
+type ValidateSectorStatusReturn = cbg.CborBool
+
+type GetNominalSectorExpirationReturn = abi.ChainEpoch


### PR DESCRIPTION
Register the missing `v18` miner actor methods and their types:
 - GenerateSectorLocationExported
 - ValidateSectorStatusExported
 - GetNominalSectorExpirationExported