### PR TITLE
Release: v0.19.0-dev

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.18.0"
+  "version": "v0.19.0-dev"
 }


### PR DESCRIPTION
Follows #448 and prepares the go-state-types development release for the nv29 skeleton work.

This bumps the release version to `v0.19.0-dev` so release-check can create the draft GitHub release and run compatibility checks. Once merged, the releaser workflow should publish the tag/release for Lotus to consume.

Closes #447.