### PR TITLE
fix: bump version to v0.19.0-rc1

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.19.0-dev"
+  "version": "v0.19.0-rc1"
 }


### PR DESCRIPTION
## Summary

- Bump `version.json` from `v0.19.0-dev` to `v0.19.0-rc1`.
- Prepare a release candidate so downstream consumers can pick up the latest dependency bumps in a tagged release.
